### PR TITLE
Support credentials for Jenkins url

### DIFF
--- a/TestResultSummaryService/.gitignore
+++ b/TestResultSummaryService/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 perffarm.config
+trssConf.json

--- a/TestResultSummaryService/ArgParser.js
+++ b/TestResultSummaryService/ArgParser.js
@@ -1,10 +1,17 @@
+const fs = require('fs');
+const { logger } = require('./Utils');
 let _config;
 
 parse = () => {
     for (let i = 0; i < process.argv.length; i++) {
         let argv = process.argv[i];
         if (argv.startsWith('--configFile=')) {
-            _config = require(argv.substring(argv.indexOf('=') + 1));
+            const file = argv.substring(argv.indexOf('=') + 1);
+            if (fs.existsSync(file)) {
+                _config = require(file);
+            } else {
+                logger.warn("Cannot find the config file: ", argv);
+            }
         }
     }
 }
@@ -13,4 +20,11 @@ getConfig = () => {
     return _config;
 }
 
-module.exports = { parse, getConfig };
+getConfigDB = () => {
+    if (_config && _config.DB && _config.DB.user && _config.DB.password) {
+        return _config.DB;
+    }
+    return null;
+}
+
+module.exports = { parse, getConfig, getConfigDB };

--- a/TestResultSummaryService/DashboardBuildInfo.json
+++ b/TestResultSummaryService/DashboardBuildInfo.json
@@ -5,20 +5,16 @@
             "Daily-ODM",
             "Daily-SPECjbb2015",
             "Daily-Liberty-DayTrader3",
-            "daily_openjdk8_j9_jcktest_ppc64le_linux",
             "daily_openjdk8_j9_jcktest_x86-64_linux",
-            "daily_openjdk9_j9_jcktest_ppc64le_linux",
-            "daily_openjdk9_j9_jcktest_x86-64_linux"
+            "daily_openjdk11_j9_jcktest_x86-64_linux"
         ],
         "default": [
-            "daily_openjdk8_j9_jcktest_ppc64le_linux",
             "daily_openjdk8_j9_jcktest_x86-64_linux",
-            "daily_openjdk9_j9_jcktest_ppc64le_linux",
-            "daily_openjdk9_j9_jcktest_x86-64_linux"
+            "daily_openjdk11_j9_jcktest_x86-64_linux"
         ]
     },
     "OpenJ9": {
-        "url": "https://ci.eclipse.org/openj9/",
+        "url": "https://ci.eclipse.org/openj9",
         "builds": [
             "Pipeline-Build-Test-All",
             "Pipeline-Build-Test-JDK8-linux_390-64_cmprssptrs",
@@ -29,12 +25,6 @@
             "Test-extended.functional-JDK8-linux_x86-64",
             "Test-extended.functional-JDK8-linux_x86-64_cmprssptrs",
             "Test-extended.functional-JDK8-win_x86-64_cmprssptrs",
-            "Test-extended.functional-JDK10-aix_ppc-64_cmprssptrs",
-            "Test-extended.functional-JDK10-linux_390-64_cmprssptrs",
-            "Test-extended.functional-JDK10-linux_ppc-64_cmprssptrs_le",
-            "Test-extended.functional-JDK10-linux_x86-64",
-            "Test-extended.functional-JDK10-linux_x86-64_cmprssptrs",
-            "Test-extended.functional-JDK10-win_x86-64_cmprssptrs",
             "Test-extended.functional-JDK11-aix_ppc-64_cmprssptrs",
             "Test-extended.functional-JDK11-linux_390-64_cmprssptrs",
             "Test-extended.functional-JDK11-linux_ppc-64_cmprssptrs_le",
@@ -47,12 +37,6 @@
             "Test-extended.system-JDK8-linux_x86-64",
             "Test-extended.system-JDK8-linux_x86-64_cmprssptrs",
             "Test-extended.system-JDK8-win_x86-64_cmprssptrs",
-            "Test-extended.system-JDK10-aix_ppc-64_cmprssptrs",
-            "Test-extended.system-JDK10-linux_390-64_cmprssptrs",
-            "Test-extended.system-JDK10-linux_ppc-64_cmprssptrs_le",
-            "Test-extended.system-JDK10-linux_x86-64",
-            "Test-extended.system-JDK10-linux_x86-64_cmprssptrs",
-            "Test-extended.system-JDK10-win_x86-64_cmprssptrs",
             "Test-extended.system-JDK11-aix_ppc-64_cmprssptrs",
             "Test-extended.system-JDK11-linux_390-64_cmprssptrs",
             "Test-extended.system-JDK11-linux_ppc-64_cmprssptrs_le",
@@ -65,12 +49,6 @@
             "Test-sanity.functional-JDK8-linux_x86-64",
             "Test-sanity.functional-JDK8-linux_x86-64_cmprssptrs",
             "Test-sanity.functional-JDK8-win_x86-64_cmprssptrs",
-            "Test-sanity.functional-JDK10-aix_ppc-64_cmprssptrs",
-            "Test-sanity.functional-JDK10-linux_390-64_cmprssptrs",
-            "Test-sanity.functional-JDK10-linux_ppc-64_cmprssptrs_le",
-            "Test-sanity.functional-JDK10-linux_x86-64",
-            "Test-sanity.functional-JDK10-linux_x86-64_cmprssptrs",
-            "Test-sanity.functional-JDK10-win_x86-64_cmprssptrs",
             "Test-sanity.functional-JDK11-aix_ppc-64_cmprssptrs",
             "Test-sanity.functional-JDK11-linux_390-64_cmprssptrs",
             "Test-sanity.functional-JDK11-linux_ppc-64_cmprssptrs_le",
@@ -83,12 +61,6 @@
             "Test-sanity.system-JDK8-linux_x86-64",
             "Test-sanity.system-JDK8-linux_x86-64_cmprssptrs",
             "Test-sanity.system-JDK8-win_x86-64_cmprssptrs",
-            "Test-sanity.system-JDK10-aix_ppc-64_cmprssptrs",
-            "Test-sanity.system-JDK10-linux_390-64_cmprssptrs",
-            "Test-sanity.system-JDK10-linux_ppc-64_cmprssptrs_le",
-            "Test-sanity.system-JDK10-linux_x86-64",
-            "Test-sanity.system-JDK10-linux_x86-64_cmprssptrs",
-            "Test-sanity.system-JDK10-win_x86-64_cmprssptrs",
             "Test-sanity.system-JDK11-aix_ppc-64_cmprssptrs",
             "Test-sanity.system-JDK11-linux_390-64_cmprssptrs",
             "Test-sanity.system-JDK11-linux_ppc-64_cmprssptrs_le",
@@ -107,22 +79,22 @@
         ]
     },
     "AdoptOpenJDK": {
-        "url": "https://ci.adoptopenjdk.net/",
+        "url": "https://ci.adoptopenjdk.net",
         "builds": [
             "openjdk8_hs_openjdktest_x86-64_linux",
             "openjdk8_hs_openjdktest_x86-64_macos",
             "openjdk8_j9_openjdktest_x86-64_linux",
-            "openjdk10_hs_openjdktest_aarch64_linux",
-            "openjdk10_hs_openjdktest_x86-64_linux",
-            "openjdk10_j9_openjdktest_x86-64_linux",
-            "openjdk10_hs_systemtest_ppc64le_linux",
-            "openjdk10_hs_systemtest_x86-64_linux"
+            "openjdk11_hs_openjdktest_aarch64_linux",
+            "openjdk11_hs_openjdktest_x86-64_linux",
+            "openjdk11_j9_openjdktest_x86-64_linux",
+            "openjdk11_hs_systemtest_ppc64le_linux",
+            "openjdk11_hs_systemtest_x86-64_linux"
         ],
         "default": [
             "openjdk8_j9_openjdktest_x86-64_linux",
             "openjdk8_hs_openjdktest_x86-64_linux",
-            "openjdk10_hs_openjdktest_x86-64_linux",
-            "openjdk10_j9_openjdktest_x86-64_linux"
+            "openjdk11_hs_openjdktest_x86-64_linux",
+            "openjdk11_j9_openjdktest_x86-64_linux"
         ]
     }
 }

--- a/TestResultSummaryService/Database.js
+++ b/TestResultSummaryService/Database.js
@@ -1,8 +1,8 @@
 const { MongoClient, ObjectID } = require( 'mongodb' );
 const ArgParser = require("./ArgParser");
 
-const credential = ArgParser.getConfig() === undefined ? "" : ArgParser.getConfig().DB.user + ':' + ArgParser.getConfig().DB.password;
-const url = 'mongodb://' + credential + '@localhost:27017/exampleDb';
+const credential = ArgParser.getConfigDB() === null ? "" : `${ArgParser.getConfigDB().user}:${ArgParser.getConfigDB().password}@`;
+const url = 'mongodb://' + credential + 'localhost:27017/exampleDb';
 
 let db;
 ( async function() {

--- a/TestResultSummaryService/README.md
+++ b/TestResultSummaryService/README.md
@@ -60,3 +60,22 @@ service TestResultsSummaryService restart
 ```
 tail -f /var/log/TestResultsSummaryService.log
 ```
+
+## Configure File
+Credentials maybe needed for the server access (i.e., database, Jenkins, etc). In this case, please provide a `--configFile=<path to config json file>` when starting the server. The default value is  `--configFile=./trssConf.json` when using `npm start`.
+
+Config file example:
+```
+{
+	"https://exampleserver2.com": {
+		"user" : "abc@example.com",
+		"password" : "123"   <=== the value can be password or token
+	},
+	"https://exampleserver1.com": {
+		"user" : "xyz@example.com",
+		"password" : "456"
+	}
+}
+```
+
+If any server name matches with url in `DashboardBuildInfo.json` or domain in build monitoring list, credentials will be used when querying these servers.

--- a/TestResultSummaryService/package.json
+++ b/TestResultSummaryService/package.json
@@ -5,7 +5,7 @@
   "main": "app.js",
   "scripts": {
     "test": "echo \"Error: no test specified! Configure in package.json\" && exit 1",
-    "start": "nodemon app.js"
+    "start": "nodemon app.js --configFile=./trssConf.json"
   },
   "repository": "",
   "keywords": [

--- a/test-result-summary-client/src/Dashboard/Defaults.js
+++ b/test-result-summary-client/src/Dashboard/Defaults.js
@@ -7,7 +7,7 @@ export default {
                 y: 0,
                 settings: {
                     serverSelected: 'AdoptOpenJDK',
-                    title: "https://ci.adoptopenjdk.net/",
+                    title: "https://ci.adoptopenjdk.net",
                 }
             },
             {
@@ -16,7 +16,7 @@ export default {
                 y: 1,
                 settings: {
                     serverSelected: 'OpenJ9',
-                    title: "https://ci.eclipse.org/openj9/",
+                    title: "https://ci.eclipse.org/openj9",
                 }
             },
             {

--- a/test-result-summary-client/src/Dashboard/TabInfo.jsx
+++ b/test-result-summary-client/src/Dashboard/TabInfo.jsx
@@ -9,7 +9,7 @@ import "./dashboard.css";
 const ReactGridLayout = WidthProvider( RGL );
 
 export default class TabInfo extends Component {
-    static VERSION = 6;
+    static VERSION = 7;
     constructor( props ) {
         super( props );
         const localKey = `dashboard-${props.tab}`;


### PR DESCRIPTION
- credentials can be added in `--configFile=<path to config json file>`
- credentials will be used for query if url matches
- remove jdk9 and jdk10 in DashboardBuildInfo.json
- update readme for how to use config file

Signed-off-by: lanxia <lan_xia@ca.ibm.com>