### PR TITLE
Remove build result check when set status to streaming

### DIFF
--- a/TestResultSummaryService/BuildMonitor.js
+++ b/TestResultSummaryService/BuildMonitor.js
@@ -45,7 +45,7 @@ class BuildMonitor {
             const buildsInDB = await testResults.getData({ url, buildName, buildNum }).toArray();
             if (!buildsInDB || buildsInDB.length === 0) {
                 let status = "NotDone";
-                if (streaming === "Yes" && allBuilds[i].result === null) {
+                if (streaming === "Yes") {
                     status = "Streaming";
                     logger.info(`Set build ${url} ${buildName} ${buildNum} status to Streaming `);
                 }


### PR DESCRIPTION
In the original code, we added the build result check to ensure we do not set streaming when the build is completed.
In this case, the build can be processed directly. We use build result != null to determine if a build is completed or not.
However, we noticed a running build could have result != null. Because this build has a build result, TRSS thinks the
build is completed and tries to process the build in the static way (without streaming). At a later stage, when
TRSS notices this build is still running, it cannot do anything but wait for the build to complete. From the user end, it
looks like the build is set to streaming but no data shows up until the whole pipeline is completed.

Remove build result check when set status to streaming. TRSS will check the build result at a later stage.
 
Signed-off-by: lanxia <lan_xia@ca.ibm.com>