### PR TITLE
Add Release Summary button and generate corresponding summary report

### DIFF
--- a/test-result-summary-client/src/App.jsx
+++ b/test-result-summary-client/src/App.jsx
@@ -11,7 +11,7 @@ import { TestCompare } from './TestCompare/';
 import { ThirdPartyAppView } from './ThirdPartyAppView/';
 import { PerfCompare } from './PerfCompare/';
 import { TabularView } from './TabularView/';
-import { AllTestsInfo, BuildDetail, DeepHistory, GitNewIssue, TestPerPlatform, PossibleIssues, TopLevelBuilds, ResultSummary } from './Build/';
+import { AllTestsInfo, BuildDetail, DeepHistory, GitNewIssue, TestPerPlatform, PossibleIssues, TopLevelBuilds, ResultSummary, ReleaseSummary } from './Build/';
 import { SearchResult } from './Search/';
 import { Settings } from './Settings/';
 
@@ -76,6 +76,7 @@ export default class App extends Component {
                                 <Route path="/searchResult" component={SearchResult} />
                                 <Route path="/resultSummary" component={ResultSummary} />
                                 <Route path="/ThirdPartyAppView" component={ThirdPartyAppView} />
+                                <Route path="/releaseSummary" component={ReleaseSummary}/>
                             </Content>
                         </ErrorBoundary>
                     </Layout>

--- a/test-result-summary-client/src/Build/BuildDetail.jsx
+++ b/test-result-summary-client/src/Build/BuildDetail.jsx
@@ -1,9 +1,11 @@
 import React, { Component } from 'react';
-import { Table } from 'antd';
+import { Button, Table } from 'antd';
 import TestBreadcrumb from './TestBreadcrumb';
 import { SearchOutput } from '../Search/';
 import { getParams, params } from '../utils/query';
 import BuildTable from "./BuildTable";
+import { Link } from 'react-router-dom';
+
 
 export default class BuildDetail extends Component {
     state = {
@@ -110,6 +112,12 @@ export default class BuildDetail extends Component {
             />
             <br />
             <BuildTable title={"Children builds"} buildData={childBuildsDataSource} />
+            <br />
+            <Link to={{ pathname: '/releaseSummary', search: params({ parentId: parentId, buildName: buildName}) }}>
+                <Button type="primary">
+                    Release Summary Report
+                </Button>
+            </Link>
         </div>
     }
 }

--- a/test-result-summary-client/src/Build/ReleaseSummary.jsx
+++ b/test-result-summary-client/src/Build/ReleaseSummary.jsx
@@ -1,0 +1,141 @@
+import React, { Component } from 'react';
+import ReactDOM from 'react-dom';
+import { getParams } from '../utils/query';
+import { Button, Tooltip, Card, Alert } from 'antd';
+import { CopyOutlined } from '@ant-design/icons';
+import TestBreadcrumb from './TestBreadcrumb';
+
+export default class ReleaseSummary extends Component{
+    state = {
+        body: "Generating Release Summary Report...",
+    }
+
+    async componentDidMount(){
+        await this.updateData();
+    }
+
+    async updateData(){
+        const { parentId } = getParams(this.props.location.search);
+        const originUrl = window.location.origin;
+        
+        //get build info
+        let fetchBuild = {};
+        fetchBuild = await fetch(`/api/getParents?id=${parentId}`, {
+            method: 'get'
+        });
+        const build = await fetchBuild.json();
+    
+        //add build and test details to report
+        let report = `TRSS [link](${originUrl}/buildDetail?parentId=${parentId}&testSummaryResult=failed&buildNameRegex=%5ETest) \n`;
+        
+        const buildUrl = build[0].buildUrl;
+        const startedBy = build[0].startBy;
+        report += `Build URL ${buildUrl} \nStarted by ${startedBy} \n`;
+
+        //get build history
+        fetchBuild = await fetch(`/api/getBuildHistory?parentId=${parentId}`, {
+            method: 'get'
+        });
+        const buildHistory = await fetchBuild.json();
+
+        for (let build of buildHistory) {
+            if (build.buildResult != "SUCCESS") {
+                report += `### ⚠️  [${build.buildName}](${build.buildUrl}) has a build result of ${build.buildResult} ⚠️\n`;
+            }
+        }
+        
+        // get all child builds info based on buildNameRegex
+        const buildNameRegex = "^Test_openjdk.*";
+        fetchBuild = await fetch(`/api/getAllChildBuilds?parentId=${parentId}&buildNameRegex=${buildNameRegex}`, {
+            method: 'get'
+        })
+        const childrenBuilds = await fetchBuild.json();
+
+        for (let testGroup of childrenBuilds) {
+            //Update report with test groups that have not succeeded
+            if (testGroup.buildResult !== "SUCCESS") {
+                const testGroupId = testGroup._id;
+                const testGroupName = testGroup.buildName;
+                const testGroupUrl = testGroup.buildUrl;
+                report += `\n[**${testGroupName}**](${testGroupUrl}) \n`;
+                if (testGroup.tests) {
+                    for (let test of testGroup.tests) {
+                        if (test.testResult === "FAILED") {
+                            const testName = test.testName;
+                            const testId = test._id;
+
+                            //get test history
+                            fetchBuild = await fetch(`/api/getHistoryPerTest?testId=${testId}&limit=100`, {
+                                method: 'get'
+                            });
+                            const history = await fetchBuild.json();
+
+                            let totalRuns = 0;
+                            let totalPasses = 0;
+                            for (let testRun of history) {
+                                totalRuns += 1;
+                                if (testRun.tests.testResult === "PASSED") {
+                                    totalPasses += 1;
+                                }
+                            }
+                            //For failed tests, add links to the deep history and possible issues list
+                            report += `${testName} => [deep history ${totalPasses}/${totalRuns} passed](${originUrl}/deepHistory?testId=${testId}) | `
+                                        + `[possible issues](${originUrl}/possibleIssues?buildId=${testGroupId}&buildName=${testGroupName}&testId=${testId}&testName=${testName}) \n`;
+                        }
+                    }
+                } else {
+                    report += `⚠️ Test Job Failed ⚠️\n`
+                } 
+            }
+        }
+        this.setState({
+            body: report
+        });
+    }
+
+    copyCodeToClipboard(){
+        const markdownText = document.getElementById('markdown-text');
+        let range, selection;
+
+        if(document.body.createTextRange){ 
+            range = document.body.createTextRange();
+            range.moveToElementText(markdownText);
+            range.select(); 
+        }
+        else if(window.getSelection){
+            selection = window.getSelection();
+            range = document.createRange();
+            range.selectNodeContents(markdownText);
+            selection.removeAllRanges();
+            selection.addRange(range);   
+        }
+        
+        let alert;
+        if(document.execCommand('Copy')){
+            alert = <Alert message="Successfully copied to clipboard" type="success" showIcon/>;
+        }
+        else{
+            alert = <Alert message="Failed to copy to clipboard" type="error" showIcon/>;
+        }
+        ReactDOM.render(alert, document.getElementById("copy-status"));
+    }
+
+    render(){
+        const { body } = this.state;
+        const { parentId, buildName} = getParams(this.props.location.search);
+        const title = "Release Summary Report for " + buildName;
+        return(
+            <div>
+                <TestBreadcrumb buildId={parentId} />
+                <div id="copy-status"></div>
+                <Card title={title} bordered={true} style={{ width: '100%' }} extra={
+                    <Tooltip title="Copy markdown report to clipboard" placement="topRight">
+                        <CopyOutlined id="copy-button" style={{ fontSize: '200%'}} onClick={() => this.copyCodeToClipboard()} />
+                    </Tooltip>
+                }>
+                    <pre className="card-body" id="markdown-text">{body}</pre>
+                </Card>
+            </div>
+        );
+    }
+}

--- a/test-result-summary-client/src/Build/index.js
+++ b/test-result-summary-client/src/Build/index.js
@@ -6,3 +6,4 @@ export { default as TestPerPlatform } from "./TestPerPlatform";
 export { default as PossibleIssues } from "./PossibleIssues";
 export { default as TopLevelBuilds } from "./TopLevelBuilds";
 export { default as ResultSummary } from "./Summary/ResultSummary";
+export {default as ReleaseSummary} from "./ReleaseSummary";


### PR DESCRIPTION
Fixes #399 

Please find a working demo [here](https://drive.google.com/file/d/1aC7axyHECdxTzeGrDli6Fv-91y3nNtOw/view?usp=sharing).

1. Added a `Release Summary Report` button alongside other build details (https://github.com/adoptium/aqa-test-tools/pull/400/commits/0b7d0ab3358370c1e8f1b3117c1758ecca445b67).
2. On being clicked, the button redirects the user to a `TRSS-Parser`-style Summary report (https://github.com/adoptium/aqa-test-tools/pull/400/commits/0b7d0ab3358370c1e8f1b3117c1758ecca445b67).
3. For each failed test, added a link to possible issues (https://github.com/adoptium/aqa-test-tools/pull/400/commits/b3c1d83ed74356773d7b35ef34c8822b9f6ce599).
4. Add a `Copy to Clipboard` button which enables the user to copy the entire report (https://github.com/adoptium/aqa-test-tools/pull/400/commits/0667a9d2b739054b8be252a80204574fb52c51b3).