### PR TITLE
Basic Authentication for GitHub API calls

### DIFF
--- a/TestResultSummaryService/README.md
+++ b/TestResultSummaryService/README.md
@@ -92,6 +92,23 @@ Config file example:
 
 If any server name matches with url in `DashboardBuildInfo.json` or domain in build monitoring list, credentials will be used when querying these servers.
 
+### GitHub credentials Config file
+In order to make authenticated requests to GitHub APIs, credentials of a valid GitHub account will be needed. Please provide an environment variable `REACT_APP_CONFIG_FILE=<name of the config json file>` in the client (i.e., in the `.env` file of `test-result-summary-client` module). The default value is `REACT_APP_CONFIG_FILE=gitConf.json`. 
+
+Please note that the config file will have to be added in the `src` folder to be valid. Hence, `REACT_APP_CONFIG_FILE=gitConf.json` will attempt to access `test-result-summary-client/src/gitConf.json`.
+
+Git Config file example:
+```
+{
+	"Git":{
+		"user": "abc",
+		"password": "123"	<=== this can also be a token
+	}
+}
+```  
+
+If the provided credentials are valid, they will be used to make authenticated requests to GitHub APIs. In case of a missing config file or invalid credentials, unauthenticated calls will be made. 
+
 ##Build Status
 
 A build can have the following status in database:

--- a/test-result-summary-client/.env
+++ b/test-result-summary-client/.env
@@ -1,0 +1,1 @@
+REACT_APP_CONFIG_FILE=gitConf.json

--- a/test-result-summary-client/.gitignore
+++ b/test-result-summary-client/.gitignore
@@ -19,3 +19,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+/src/gitConf.json

--- a/test-result-summary-client/src/Build/PossibleIssues.jsx
+++ b/test-result-summary-client/src/Build/PossibleIssues.jsx
@@ -2,8 +2,13 @@ import React, { Component } from 'react';
 import { Table } from 'antd';
 import TestBreadcrumb from './TestBreadcrumb';
 import { getParams } from '../utils/query';
+import { getGitConfig } from '../utils/parseGitConfig';
 
 import './table.css';
+
+//Attempt to fetch GitHub credentials for authenticated API requests
+const gitConfig = getGitConfig();
+const credentials = gitConfig === null ? "" : btoa(`${gitConfig.user}:${gitConfig.password}`);
 
 export default class PossibleIssues extends Component {
     state = {
@@ -25,8 +30,12 @@ export default class PossibleIssues extends Component {
 
         const response = await fetch(`https://api.github.com/search/issues?q=${testName}+state:open+repo:AdoptOpenJDK/openjdk-tests` +
                     `+repo:AdoptOpenJDK/openjdk-infrastructure+repo:AdoptOpenJDK/openjdk-build+repo:adoptium/aqa-systemtest+repo:adoptium/TKG${additionalRepo}`, {
-            method: 'get'
+            method: 'get',
+            headers: {
+                Authorization: `Basic ${credentials}` 
+            }
         });
+
         if (response.ok) {
             const relatedIssues = await response.json();
             let dataSource = {};

--- a/test-result-summary-client/src/utils/parseGitConfig.js
+++ b/test-result-summary-client/src/utils/parseGitConfig.js
@@ -1,0 +1,14 @@
+export const getGitConfig = () => {
+	const file = process.env.REACT_APP_CONFIG_FILE;
+	
+	try{
+		const _config = require('../' + file);
+		if(_config && _config.Git && _config.Git.user && _config.Git.password){
+			return _config.Git;
+		}
+	} catch(e){
+		console.log("Cannot find config file: ", file);
+	}
+	
+	return null;
+}


### PR DESCRIPTION
Fixes #409 

1. Added Basic Authentication to GitHub API calls while fetching Possible Issues. 
2. Added an environment variable for configuration file that has the GitHub credentials (Added a .env variable "REACT_APP_CONFIG_FILE"  for specifying the name of the config file)
3. Created a simple parser to fetch the credentials from the config file.
4. Updated README to add instructions to specify the config file.

Notes:
1. If the credentials or the config file are not found, unauthenticated calls are made.
2. The config file needs to be added inside the src folder (defaults to gitConf.json)