### PR TITLE
fix testResult of undefined in testTable

### DIFF
--- a/test-result-summary-client/src/Build/AllTestsInfo.jsx
+++ b/test-result-summary-client/src/Build/AllTestsInfo.jsx
@@ -47,7 +47,7 @@ export default class Build extends Component {
         await Promise.all( buildIds.map( async buildId =>{
             const {testResult, parent, error} = await this.getTestResult(buildId, limitParam);
             testData = testData.concat(testResult);
-            if ( parents.length === 0 ) {
+            if ( parent.length > parents.length || parents.length === 0 ) {
                 parents = parent;
             }
             if (error) {

--- a/test-result-summary-client/src/Build/TestTable.jsx
+++ b/test-result-summary-client/src/Build/TestTable.jsx
@@ -6,6 +6,8 @@ import { params } from '../utils/query';
 import { Link } from 'react-router-dom';
 import renderDuration from './Duration';
 
+const testResultSortingArray = ['FAILED', 'PASSED', 'DISABLED', 'SKIPPED', 'N/A'];
+
 export default class TestTable extends Component {
     state = {
         filteredData: [],
@@ -24,16 +26,30 @@ export default class TestTable extends Component {
     }
 
     render() {
-        const { title, testData, parents } = this.props;
+        const { title, parents } = this.props;
+        let { testData } = this.props;
         const { filteredData } = this.state;
-        const renderResult = ({ testResult, testId }) => {
-            return <div>
+        const renderResult = (value) => {
+            if (value) {
+                const { testId, testResult } = value
+                return <div>
                 {testId ? <Link to={{ pathname: '/output/test', search: params({ id: testId }) }}
                     style={{ color: testResult === "PASSED" ? "#2cbe4e" : (testResult === "FAILED" ? "#f50" : "#DAA520") }}>
                     {testResult}
                 </Link> : testResult}
             </div>;
+            } else {
+                return <div>
+                    N/A
+                </div>
+            }
         };
+
+        if (parents) {
+            testData = testData.sort(function(a, b){  
+                return testResultSortingArray.indexOf(a[0].testResult) - testResultSortingArray.indexOf(b[0].testResult);
+            })
+        }
 
         const renderAction = (value, row) => {
             const { testId } = value;


### PR DESCRIPTION
-If a test does not appear in previous build, set to N/A
-Sort test results based on a specific order: FAILED, PASSED, DISABLED, SKIPPED, N/A
- related: https://github.com/adoptium/aqa-test-tools/issues/282

Signed-off-by: OscarQQ <Yixin.Qian@ibm.com>