### PR TITLE
Add collection of closed issues to DeepAQAtik

### DIFF
--- a/MachineLearningPrototype/dataCollection/collect_data.py
+++ b/MachineLearningPrototype/dataCollection/collect_data.py
@@ -123,7 +123,6 @@ def fetch_github_issues(args, db):
 			num_issues = 0
 			since = None
 			
-			#Get the last updated time if the repo is found
 			if since_info:
 				since = since_info['last_updated_time']
 			

--- a/MachineLearningPrototype/dataCollection/collect_data.py
+++ b/MachineLearningPrototype/dataCollection/collect_data.py
@@ -48,6 +48,8 @@ def store_issue_details(issue, repo, db):
 	issue_details['title'] = issue['title']
 	issue_details['created_at'] = issue['created_at']
 	issue_details['updated_at'] = issue['updated_at']
+	issue_details['labels'] = issue['labels']
+	
 	issue_details['issue_content_path'] = issue_content_path
 	# issue_details['test_output_path'] = test_output_path
 
@@ -65,11 +67,11 @@ def fetch_new_issues(repo, since, auth_token, db):
 	Fetch all new open issues in the repo since `since`
 	"""
 	page_number = 1
-	num_open_issues = 0
+	num_issues = 0
 	
 	query_url = f'https://api.github.com/repos/{repo}/issues'
 	params = {'accept': 'application/vnd.github.v3+json',
-			  'state': 'open',
+			  'state': 'all',
 			  'since': since,
 			  'per_page': 100,
 			  'page': page_number,}
@@ -89,12 +91,11 @@ def fetch_new_issues(repo, since, auth_token, db):
 		for r in response:
 			if 'pull_request' not in r:
 				store_issue_details(r, repo, db)	
-				num_open_issues += 1
+				num_issues += 1
 
 		page_number += 1
 
-	pprint(f'Number of new issues found: {num_open_issues}')
-	return num_open_issues
+	pprint(f'Number of new issues found: {num_issues}')
 
 def fetch_github_issues(args, db):
 	"""
@@ -111,29 +112,33 @@ def fetch_github_issues(args, db):
 
 			#Get the last updated time for the repo
 			since_info = get_collection_record({'repository': repo}, None, 'LastUpdatedInfo', db)
-			
-			num_issues = 0
 			since = None
 
-			#Get the last_updated time and total_issues_collected if the repo is found
+			#Get the last_updated time if the repo is found
 			if since_info:
 				since = since_info['last_updated_time']
-				num_issues = since_info['total_issues_collected']
-	
+			
 			pprint(f"Fetching open issues for {repo}")
 
-			num_issues += fetch_new_issues(repo, since, auth_token, db)
+			fetch_new_issues(repo, since, auth_token, db)
 
+			num_open_issues = db['Issues'].count_documents({'state': 'open'})
+			num_issues = db['Issues'].count_documents({})
+			
 			pprint(f'Total number of issues: {num_issues}')
-
+			pprint(f'Total number of open issues: {num_open_issues}')
+			
 			#Store the last updated time for the repo
 			since = datetime.now().isoformat()
 			since_record_to_store = {
 				'repository': repo, 
 				'last_updated_time': since,
-				'total_issues_collected': num_issues
+				'total_issues_collected': num_issues,
+				'total_open_issues': num_open_issues
 			}
 			store_in_db(since_record_to_store, "LastUpdatedInfo", db, primary_key='repository')
+
+			pprint('-----------------------------------')
 			
 		end = time.time()
 		pprint(f'Time taken to fetch issues: {end-start} seconds')

--- a/MachineLearningPrototype/dataCollection/collect_data.py
+++ b/MachineLearningPrototype/dataCollection/collect_data.py
@@ -29,32 +29,6 @@ def get_collection_record(query_params, field_params, collection_name, db):
 	db_col = db[collection_name]
 	return db_col.find_one(query_params, field_params)
 
-def store_issue_on_db(data, db, collection_name='Issues', primary_key='url'):
-	record_id = {primary_key: data[primary_key]}
-	existing_issue = get_collection_record(record_id, None, collection_name, db)
-
-	new_issue_count = 1
-	new_open_issue_count = int(data['state'] == 'open')
-
-	if existing_issue:
-		#Not a new issue
-		new_issue_count = 0
-
-		old_state = existing_issue['state']
-		new_state = data['state']
-
-		if (new_state == 'open'):
-			#New open issue only if previously closed
-			new_open_issue_count = int(old_state == 'closed')
-		else:
-			#If previously open, reduce open_issues count
-			new_open_issue_count = -int(old_state == 'open')
-
-	store_in_db(data, collection_name, db, primary_key)
-
-	return new_issue_count, new_open_issue_count
-		
-		
 def store_issue_details(issue, repo, db):
 	"""
 	Get issue details to be stored in DB and store issue text on filesystem
@@ -83,11 +57,9 @@ def store_issue_details(issue, repo, db):
 	store_on_fs(issue['body'], issue_content_path)
 	
 	#Store issue details in db.Issues Table
-	new_issue_count, new_open_issue_count = store_issue_on_db(issue_details, db, "Issues", "url")
+	store_in_db(issue_details, 'Issues', db, 'url')
 
 	#To do: Add issue_details['test_output_path'] and store test_output in filesystem
-
-	return new_issue_count, new_open_issue_count
 
 
 def fetch_new_issues(repo, since, auth_token, db):
@@ -96,7 +68,6 @@ def fetch_new_issues(repo, since, auth_token, db):
 	"""
 	page_number = 1
 	new_issues_count = 0
-	new_open_issues_count = 0
 	
 	query_url = f'https://api.github.com/repos/{repo}/issues'
 	params = {'accept': 'application/vnd.github.v3+json',
@@ -119,15 +90,12 @@ def fetch_new_issues(repo, since, auth_token, db):
 
 		for r in response:
 			if 'pull_request' not in r:
-				new_issue_count, new_open_issue_count = store_issue_details(r, repo, db)	
-				new_issues_count += new_issue_count
-				new_open_issues_count += new_open_issue_count
+				store_issue_details(r, repo, db)	
+				new_issues_count += 1
 
 		page_number += 1
 
 	pprint(f'Number of new issues found: {new_issues_count}')
-
-	return new_issues_count, new_open_issues_count
 
 def fetch_github_issues(args, db):
 	"""
@@ -145,32 +113,20 @@ def fetch_github_issues(args, db):
 			#Get the last updated time for the repo
 			since_info = get_collection_record({'repository': repo}, None, 'LastUpdatedInfo', db)
 			since = None
-			num_issues = 0
-			num_open_issues = 0
-
+			
 			#Get the last_updated time if the repo is found
 			if since_info:
 				since = since_info['last_updated_time']
-				num_issues = since_info['total_issues_collected']
-				num_open_issues = since_info['total_open_issues']
 			
 			pprint(f"Fetching new issues for {repo}")
 
-			new_issues, new_open_issues = fetch_new_issues(repo, since, auth_token, db)
+			fetch_new_issues(repo, since, auth_token, db)
 
-			num_open_issues += new_open_issues
-			num_issues += new_issues 
-			
-			pprint(f'Total number of issues: {num_issues}')
-			pprint(f'Total number of open issues: {num_open_issues}')
-			
 			#Store the last updated time for the repo
 			since = datetime.now().isoformat()
 			since_record_to_store = {
 				'repository': repo, 
 				'last_updated_time': since,
-				'total_issues_collected': num_issues,
-				'total_open_issues': num_open_issues
 			}
 			store_in_db(since_record_to_store, "LastUpdatedInfo", db, primary_key='repository')
 

--- a/MachineLearningPrototype/dataCollection/collect_data.py
+++ b/MachineLearningPrototype/dataCollection/collect_data.py
@@ -123,7 +123,7 @@ def fetch_github_issues(args, db):
 			num_issues = 0
 			since = None
 			
-			#Get the last_updated time if the repo is found
+			#Get the last updated time if the repo is found
 			if since_info:
 				since = since_info['last_updated_time']
 			

--- a/MachineLearningPrototype/dataCollection/collect_data.py
+++ b/MachineLearningPrototype/dataCollection/collect_data.py
@@ -98,7 +98,7 @@ def fetch_new_issues(repo, since, auth_token, db):
 
 		for r in response:
 			if 'pull_request' not in r:
-				store_issue_details(r, repo, db)	
+				store_issue_details(r, repo, db)
 				new_issues_count += 1
 
 		page_number += 1


### PR DESCRIPTION
Solves #447 

1. The pipeline now collects all issues from specified github repositories (open and closed).
2. Labels are added to issue information stored on DB.
3. Total number of open issues are found by counting {'state': 'open'} issues from the DB collection. 
4. Total number of issues are found by counting all documents in the collection.