### PR TITLE
Added extract_jenkins_link_and_testname function

### DIFF
--- a/MachineLearningPrototype/dataCollection/config.json
+++ b/MachineLearningPrototype/dataCollection/config.json
@@ -1,0 +1,3 @@
+{
+	"trss_servers": ["https://trss.adoptium.net"]
+}

--- a/MachineLearningPrototype/utils/preprocess_data.py
+++ b/MachineLearningPrototype/utils/preprocess_data.py
@@ -76,8 +76,8 @@ def extract_jenkins_link_and_testname(content):
 
     pattern3 = r"[a-zA-Z].+\d+(?=_FAILED)" # For "testname_FAILED" to testname
     splitted_content = content.split()
-    for string in splitted_content:
-        extracted_test = re.findall(pattern3, string)
+    for word in splitted_content:
+        extracted_test = re.findall(pattern3, word)
         test_names += extracted_test
 
     pattern4 = r"(?<=Test Name: ).+_\d+" # "Test Name: HCRLateAttachWorkload_0" to "HCRLateAttachWorkload_0"

--- a/MachineLearningPrototype/utils/preprocess_data.py
+++ b/MachineLearningPrototype/utils/preprocess_data.py
@@ -1,5 +1,6 @@
 import re
-
+import requests
+import json
 
 def remove_time_stamp(content):
     if not content:
@@ -15,3 +16,71 @@ def extract_quotation_content(content):
     if (len(substring) >= 1):
         result=' '.join(substring)
         return result
+
+def query_trss_for_jenkins_output(jenkins_url, test_name, trss_servers=["https://trss.adoptium.net"]):
+    #Get build info from TRSS
+    query_url = "https://trss.adoptium.net/api/parseJenkinsUrl"
+    query_params = {"jenkinsUrl": jenkins_url}
+    output = requests.get(query_url, query_params)
+    output_dict = json.loads(output.content)
+
+    if "output" not in output_dict:
+        raise Exception("No response received from TRSS while parsing Jenkins Url")
+        return ""
+
+    output_dict = output_dict["output"]
+
+    if output_dict["errorMsg"]:
+        raise Exception("Failed to parse Jenkins Url with error message: " + output_dict["errorMsg"])
+        return ""
+
+    url = output_dict["serverUrl"]
+    build_name = output_dict["buildName"]
+    build_num = output_dict["buildNum"]
+
+    query_params = {"url": url,
+                    "buildName": build_name,
+                    "buildNum": build_num,
+                    "testName": test_name,}
+
+    print("Query parameters:")
+    print(query_params)
+
+    for server in trss_servers:
+        #Try to fetch test data from server
+        query_url = f"{server}/api/getOutputByTestInfo"
+        print(f"\nQuerying url: {query_url}")
+
+        output = requests.get(query_url, query_params)
+        data = json.loads(output.content)
+
+        if "output" in data:
+            return data["output"]
+
+    print("Couldn't find data for test")
+    return ""
+
+def extract_jenkins_link_and_testname(content):
+    jenkins_links = []
+    test_names = []
+
+    pattern = r"(https:\/\/.+\/job\/Test_openjdk\d+.+\/\d+)"
+    adoptium_jenkins_links = re.findall(pattern, content)
+    jenkins_links += adoptium_jenkins_links
+
+    pattern2 = r"(?<=\`)Test_openjdk\d+.+?\/?(?=\`)"
+    internal_jenkins_job_names = re.findall(pattern2, content)
+    extracted_internal_links = [''.join(('https://internal_jenkins/job/',x)) for x in internal_jenkins_job_names]
+    jenkins_links += extracted_internal_links
+
+    pattern3 = r"[a-zA-Z].+\d+(?=_FAILED)" # For "testname_FAILED" to testname
+    splitted_content = content.split()
+    for string in splitted_content:
+        extracted_test = re.findall(pattern3, string)
+        test_names += extracted_test
+
+    pattern4 = r"(?<=Test Name: ).+_\d+" # "Test Name: HCRLateAttachWorkload_0" to "HCRLateAttachWorkload_0"
+    special_test_names = re.findall(pattern4, content)
+    test_names += special_test_names
+
+    return jenkins_links, test_names


### PR DESCRIPTION
Added the function `extract_jenkins_link_and_testname` in the `preprocess_data.py` file to extract the Jenkins URL and Testnames.
For the Sample input:
```
Failing job link: https://ci.adoptopenjdk.net/job/Test_openjdk11_j9_sanity.openjdk_x86-64_linux/34/consoleFull
Failing job link 2: https://ci.adoptopenjdk.net/job/Test_openjdk17_j9_sanity.openjdk_x86-64_linux/99
From an internal build `Test_openjdk11_j9_sanity.openjdk_s390x_linux/83/`
From the second internal build Test_openjdk17_j9_sanity.openjdk_s390x_linux/99/ (rhel7s390x-4-3)
[2021-06-18T03:04:20.479Z] jdk_util_0_FAILED
jdk_nio_0_FAILED
```
We get the output:
```
(['https://ci.adoptopenjdk.net/job/Test_openjdk11_j9_sanity.openjdk_x86-64_linux/34', 'https://ci.adoptopenjdk.net/job/Test_openjdk17_j9_sanity.openjdk_x86-64_linux/99', 'https://internal_jenkins/job/Test_openjdk11_j9_sanity.openjdk_s390x_linux/83/'], ['jdk_util_0', 'jdk_nio_0'])
```
Related issue [#444](https://github.com/adoptium/aqa-test-tools/issues/444)


Signed-off-by: 2001asjad <iitasjad2001@gmail.com>