### PR TITLE
Added extracted Jenkins URLs and Testnames to the DB

### DIFF
--- a/MachineLearningPrototype/dataCollection/collect_data.py
+++ b/MachineLearningPrototype/dataCollection/collect_data.py
@@ -70,29 +70,28 @@ def store_issue_details(issue, repo, db):
 	jenkins_links = content_extracted[0]
 	test_names = content_extracted[1]
 	if jenkins_links != []:
-    	issue_details['issue_quoted_jenkins_links'] = jenkins_links
+    		issue_details['issue_quoted_jenkins_links'] = jenkins_links
 	if test_names != []:
-    	issue_details['issue_quoted_test_names'] = test_names
+    		issue_details['issue_quoted_test_names'] = test_names
 
 	if (jenkins_links and test_names):
 		path_list = []
-        for link in jenkins_links:
-			new_string = link.split('/')
-			final_string = ''.join(new_string)
-            for test in test_names:
-                issue_uid2 = f'{repo_name}_{issue_number}_{final_string}_{test}.txt'
-                jenkins_output_path = f'./data/GitHubData/JenkinsOutput/{issue_uid2}'
+		for link in jenkins_links:
+				new_string = link.split('/')
+				final_string = ''.join(new_string)
+		    		for test in test_names:
+					issue_uid2 = f'{repo_name}_{issue_number}_{final_string}_{test}.txt'
+					jenkins_output_path = f'./data/GitHubData/JenkinsOutput/{issue_uid2}'
 
-				if os.path.isfile(issue_uid2):
-                    path_list.append(jenkins_output_path)
-				
+					if os.path.isfile(issue_uid2):
+			    			path_list.append(jenkins_output_path)
 
-				else:
-                    trss_jenkins_output = query_trss_for_jenkins_output(link, test)
-                    if trss_jenkins_output:
-                        store_on_fs(trss_jenkins_output, jenkins_output_path)
-						path_list.append(jenkins_output_path)
-                        
+					else:
+			    			trss_jenkins_output = query_trss_for_jenkins_output(link, test)
+			    			if trss_jenkins_output:
+							store_on_fs(trss_jenkins_output, jenkins_output_path)
+							path_list.append(jenkins_output_path)
+
 		if path_list:
 			issue_details['jenkins_output_path_list'] = path_list
 

--- a/MachineLearningPrototype/dataCollection/collect_data.py
+++ b/MachineLearningPrototype/dataCollection/collect_data.py
@@ -8,7 +8,8 @@ from pprint import pprint
 import pymongo
 import sys
 sys.path.append("../utils/")
-from preprocess_data import extract_quotation_content
+from preprocess_data import extract_quotation_content, query_trss_for_jenkins_output, extract_jenkins_link_and_testname
+import os
 
 def store_in_db(data, collection_name, db, primary_key='url'):
 	"""
@@ -55,7 +56,7 @@ def store_issue_details(issue, repo, db):
 	issue_details['created_at'] = issue['created_at']
 	issue_details['updated_at'] = issue['updated_at']
 	issue_details['labels'] = issue['labels']
-	
+
 	issue_details['issue_content_path'] = issue_content_path
 	# issue_details['test_output_path'] = test_output_path
 	issue_details['issue_content_quotation_path'] = issue_content_quotation_path
@@ -64,6 +65,38 @@ def store_issue_details(issue, repo, db):
 	store_quotation_result = store_on_fs(extract_quotation_content(issue['body']), issue_content_quotation_path)
 	if store_quotation_result:
 		issue_details['issue_content_quotation_path'] = issue_content_quotation_path
+
+	content_extracted = extract_jenkins_link_and_testname(issue['body'])
+	jenkins_links = content_extracted[0]
+	test_names = content_extracted[1]
+	if jenkins_links != []:
+    	issue_details['issue_quoted_jenkins_links'] = jenkins_links
+	if test_names != []:
+    	issue_details['issue_quoted_test_names'] = test_names
+
+	if (jenkins_links and test_names):
+		path_list = []
+        for link in jenkins_links:
+			new_string = link.split('/')
+			final_string = ''.join(new_string)
+            for test in test_names:
+                issue_uid2 = f'{repo_name}_{issue_number}_{final_string}_{test}.txt'
+                jenkins_output_path = f'./data/GitHubData/JenkinsOutput/{issue_uid2}'
+
+				if os.path.isfile(issue_uid2):
+                    path_list.append(jenkins_output_path)
+				
+
+				else:
+                    trss_jenkins_output = query_trss_for_jenkins_output(link, test)
+                    if trss_jenkins_output:
+                        store_on_fs(trss_jenkins_output, jenkins_output_path)
+						path_list.append(jenkins_output_path)
+                        
+		if path_list:
+			issue_details['jenkins_output_path_list'] = path_list
+
+
 	#Store issue details in db.Issues Table
 	store_in_db(issue_details, 'Issues', db, 'url')
 
@@ -122,10 +155,10 @@ def fetch_github_issues(args, db):
 			since_info = get_collection_record({'repository': repo}, None, 'LastUpdatedInfo', db)
 			num_issues = 0
 			since = None
-			
+
 			if since_info:
 				since = since_info['last_updated_time']
-			
+
 			pprint(f"Fetching new issues for {repo}")
 
 			fetch_new_issues(repo, since, auth_token, db)

--- a/MachineLearningPrototype/utils/preprocess_data.py
+++ b/MachineLearningPrototype/utils/preprocess_data.py
@@ -65,9 +65,11 @@ def extract_jenkins_link_and_testname(content):
     jenkins_links = []
     test_names = []
 
+    splitted_content = content.split()
     pattern = r"(https:\/\/.+\/job\/Test_openjdk\d+.+\/\d+)"
-    adoptium_jenkins_links = re.findall(pattern, content)
-    jenkins_links += adoptium_jenkins_links
+    for word in splitted_content:
+        adoptium_jenkins_links = re.findall(pattern, word)
+        jenkins_links += adoptium_jenkins_links
 
     pattern2 = r"(?<=\`)Test_openjdk\d+.+?\/?(?=\`)"
     internal_jenkins_job_names = re.findall(pattern2, content)
@@ -75,7 +77,6 @@ def extract_jenkins_link_and_testname(content):
     jenkins_links += extracted_internal_links
 
     pattern3 = r"[a-zA-Z].+\d+(?=_FAILED)" # For "testname_FAILED" to testname
-    splitted_content = content.split()
     for word in splitted_content:
         extracted_test = re.findall(pattern3, word)
         test_names += extracted_test


### PR DESCRIPTION
Following tasks have been done by calling `extract_jenkins_link_and_testname` function with parameter `issue[body]`:

- With `issue[body]`, used function `extract_jenkins_link_and_testname` to generate `(links_list, names_list)`
- Used  `issue_details["issue_quoted_jenkins_links"]` and `issue_details["issue_quoted_test_names"]` to store in DB.

Attaching Screenshot for the Sample DB:
![DB](https://user-images.githubusercontent.com/60435499/124362137-e0af2080-dc50-11eb-8f4c-f140b7e1b4da.PNG)
Depends on the PR [#474](https://github.com/adoptium/aqa-test-tools/pull/474)
Based on the issue [#486](https://github.com/adoptium/aqa-test-tools/issues/486)

Signed-off-by: 2001asjad <iitasjad2001@gmail.com>