### PR TITLE
Enhance Release Summary Report logic

### DIFF
--- a/test-result-summary-client/src/Build/BuildDetail.jsx
+++ b/test-result-summary-client/src/Build/BuildDetail.jsx
@@ -106,7 +106,7 @@ export default class BuildDetail extends Component {
             <br />
             <BuildTable title={"Children builds"} buildData={childBuildsDataSource} />
             <br />
-            <Link to={{ pathname: '/releaseSummary', search: params({ parentId: parentId, buildName: buildName}) }}>
+            <Link to={{ pathname: '/releaseSummary', search: params({ parentId, buildName }) }}>
                 <Button type="primary">
                     Release Summary Report
                 </Button>


### PR DESCRIPTION
- Use Promise.all() to send queries in parallel to improve the performance
- Remove unnecessary queries
- Use params() to handle special characters in parameter values (i.e., test name)
- Add title and Grid view link
- Show actual build results instead of general message `Test Job Failed`
- Add different icons for UNSTABLE and FAILURE
- separate build and test build results into two different groups
- Sort build names in the report, so Version/Impl/Platform and Parent/Child are grouped together
- Handle errors
- in the performance testing, we increased report generation time from 26 secs to 5 secs

Resolves: adoptium#501 and adoptium#506

Signed-off-by: lanxia <lan_xia@ca.ibm.com>