### PR TITLE
Add sort on State on possibleIssues page

### DIFF
--- a/test-result-summary-client/src/Build/PossibleIssues.jsx
+++ b/test-result-summary-client/src/Build/PossibleIssues.jsx
@@ -156,6 +156,11 @@ export default class PossibleIssues extends Component {
                     title: 'State',
                     dataIndex: 'issueState',
                     key: 'issueState',
+                    sorter: (a, b) => {
+                        if (a.issueState === b.issueState) return 0;
+                        else if (a.issueState === 'open') return -1;
+                        else return 1; 
+                    }
                 },
                 {
                     title: 'Related Degree',


### PR DESCRIPTION
This update adds a sorting feature on State in the possible issues page.

Fixes: #589

Signed-off-by: Nadeen Mohamed <nadeen@ualberta.ca>