### PR TITLE
removed release summary report button from buildDetail page.

### DIFF
--- a/test-result-summary-client/src/Build/BuildDetail.jsx
+++ b/test-result-summary-client/src/Build/BuildDetail.jsx
@@ -133,15 +133,6 @@ export default class BuildDetail extends Component {
                     title={'Children builds'}
                     buildData={childBuildsDataSource}
                 />
-                <br />
-                <Link
-                    to={{
-                        pathname: '/releaseSummary',
-                        search: params({ parentId, buildName }),
-                    }}
-                >
-                    <Button type="primary">Release Summary Report</Button>
-                </Link>
             </div>
         );
     }


### PR DESCRIPTION
the task was to remove a button from the build page. so I have done it, you can see the results below.

before:
![156840848-ebb072bf-8591-4451-808e-ff98a0bea17b](https://user-images.githubusercontent.com/75799016/157401153-7c9e5a7b-0a06-4c81-93bc-c4f9075747db.png)

After:

![Screenshot (425)](https://user-images.githubusercontent.com/75799016/157401887-79984dee-8d33-4cce-ab36-4e227081feac.png)

Fixes: #626
Signed-off-by: Suhas Khobragade <suhaskhobragade19@gmail.com>