### PR TITLE
Added test links in failed jobs in TRSS Release Summary Report

### DIFF
--- a/test-result-summary-client/src/Build/Output/Output.jsx
+++ b/test-result-summary-client/src/Build/Output/Output.jsx
@@ -29,9 +29,9 @@ export default class Output extends Component {
 
     async updateData(outputType) {
         let data = {};
-        const { id } = getParams(this.props.location.search);
+        const { testId } = getParams(this.props.location.search);
         if (outputType === 'test') {
-            const info = await fetchData(`/api/getTestById?id=${id} `);
+            const info = await fetchData(`/api/getTestById?id=${testId} `);
             const result = await fetchData(
                 `/api/getOutputById?id=${info.testOutputId}`
             );
@@ -50,7 +50,7 @@ export default class Output extends Component {
                 buildUrl: dataInfo.buildUrl,
             };
         } else {
-            const results = await fetchData(`/api/getData?_id=${id} `);
+            const results = await fetchData(`/api/getData?_id=${testId} `);
             const info = results[0];
             if (info && info.buildOutputId) {
                 const result = await fetchData(

--- a/test-result-summary-client/src/Build/Output/Output.jsx
+++ b/test-result-summary-client/src/Build/Output/Output.jsx
@@ -29,9 +29,9 @@ export default class Output extends Component {
 
     async updateData(outputType) {
         let data = {};
-        const { testId } = getParams(this.props.location.search);
+        const { id } = getParams(this.props.location.search);
         if (outputType === 'test') {
-            const info = await fetchData(`/api/getTestById?id=${testId} `);
+            const info = await fetchData(`/api/getTestById?id=${id} `);
             const result = await fetchData(
                 `/api/getOutputById?id=${info.testOutputId}`
             );

--- a/test-result-summary-client/src/Build/Output/Output.jsx
+++ b/test-result-summary-client/src/Build/Output/Output.jsx
@@ -50,7 +50,7 @@ export default class Output extends Component {
                 buildUrl: dataInfo.buildUrl,
             };
         } else {
-            const results = await fetchData(`/api/getData?_id=${testId} `);
+            const results = await fetchData(`/api/getData?_id=${id} `);
             const info = results[0];
             if (info && info.buildOutputId) {
                 const result = await fetchData(

--- a/test-result-summary-client/src/Build/ReleaseSummary.jsx
+++ b/test-result-summary-client/src/Build/ReleaseSummary.jsx
@@ -84,7 +84,7 @@ export default class ReleaseSummary extends Component {
                                             }
                                             //For failed tests, add links to the deep history and possible issues list
                                             failedTestSummary[buildName] +=
-                                                `[${testName}](${originUrl}/output/test?id=${_id}) => [deep history ${totalPasses}/${history.length} passed](${originUrl}/deepHistory?testId=${testId}) | ` +
+                                                `[${testName}](${originUrl}/output/test?testId=${_id}) => [deep history ${totalPasses}/${history.length} passed](${originUrl}/deepHistory?testId=${testId}) | ` +
                                                 `[possible issues](${originUrl}/possibleIssues${params(
                                                     {
                                                         buildId,

--- a/test-result-summary-client/src/Build/ReleaseSummary.jsx
+++ b/test-result-summary-client/src/Build/ReleaseSummary.jsx
@@ -84,7 +84,7 @@ export default class ReleaseSummary extends Component {
                                             }
                                             //For failed tests, add links to the deep history and possible issues list
                                             failedTestSummary[buildName] +=
-                                                `${testName} => [deep history ${totalPasses}/${history.length} passed](${originUrl}/deepHistory?testId=${testId}) | ` +
+                                                `[${testName}](${originUrl}/output/test?id=${_id}) => [deep history ${totalPasses}/${history.length} passed](${originUrl}/deepHistory?testId=${testId}) | ` +
                                                 `[possible issues](${originUrl}/possibleIssues${params(
                                                     {
                                                         buildId,

--- a/test-result-summary-client/src/Build/ReleaseSummary.jsx
+++ b/test-result-summary-client/src/Build/ReleaseSummary.jsx
@@ -84,7 +84,7 @@ export default class ReleaseSummary extends Component {
                                             }
                                             //For failed tests, add links to the deep history and possible issues list
                                             failedTestSummary[buildName] +=
-                                                `[${testName}](${originUrl}/output/test?testId=${_id}) => [deep history ${totalPasses}/${history.length} passed](${originUrl}/deepHistory?testId=${testId}) | ` +
+                                                `[${testName}](${originUrl}/output/test?id=${testId}) => [deep history ${totalPasses}/${history.length} passed](${originUrl}/deepHistory?testId=${testId}) | ` +
                                                 `[possible issues](${originUrl}/possibleIssues${params(
                                                     {
                                                         buildId,


### PR DESCRIPTION
It would seem that the master branch did not actually have the test links implemented. I apologize for the duplicate PR. In this PR, there should be test links for each failed test. This is partial fix of #624 

Fixes: #630 

Signed-off-by: Tommy Tho [tommythowm@gmail.com](mailto:tommythowm@gmail.com)

## Report Preview

#### Release Summary Report for jdk8u-linux-aarch64-dragonwell 
**Report generated at:** Wed, 30 Mar 2022 18:04:23 GMT 
 
TRSS [Build](http://localhost:3000/buildDetail?parentId=60e60be6a2e5057f5cda32f2&testSummaryResult=failed&buildNameRegex=%5ETest) and TRSS [Grid View](http://localhost:3000/resultSummary?parentId=60e60be6a2e5057f5cda32f2) 
Jenkins Build URL https://ci.adoptopenjdk.net/job/Test_openjdk11_hs_extended.openjdk_x86-64_linux/30/ 
Started by upstream project "build-scripts/jobs/jdk11u/jdk11u-linux-x64-hotspot" build number 991 at 2021-06-26, 11:51:07 a.m. 

 --- 

 --- 

[**Test_openjdk11_hs_extended.openjdk_x86-64_linux**](https://ci.adoptopenjdk.net/job/Test_openjdk11_hs_extended.openjdk_x86-64_linux_testList_0/5/) ⚠️ UNSTABLE ⚠️
<details><summary>java -version output</summary>

```
openjdk version "11.0.12" 2021-07-20

OpenJDK Runtime Environment Temurin-11.0.12+5 (build 11.0.12+5)

OpenJDK 64-Bit Server VM Temurin-11.0.12+5 (build 11.0.12+5, mixed mode)
```
</details>

[jdk_tools_1](http://localhost:3000/output/test?id=60e60cc8631d857f69d6218f) => [deep history 0/1 passed](http://localhost:3000/deepHistory?testId=60e60cc8631d857f69d6218f) | [possible issues](http://localhost:3000/possibleIssues?buildId=60e60c00631d857f69d6201a&buildName=Test_openjdk11_hs_extended.openjdk_x86-64_linux&testId=60e60cc8631d857f69d6218f&testName=jdk_tools_1) 
[jdk_security_infra_1](http://localhost:3000/output/test?id=60e60cc8631d857f69d621a1) => [deep history 0/1 passed](http://localhost:3000/deepHistory?testId=60e60cc8631d857f69d621a1) | [possible issues](http://localhost:3000/possibleIssues?buildId=60e60c00631d857f69d6201a&buildName=Test_openjdk11_hs_extended.openjdk_x86-64_linux&testId=60e60cc8631d857f69d621a1&testName=jdk_security_infra_1) 

[**Test_openjdk11_hs_extended.openjdk_x86-64_linux_testList_2**](https://ci.adoptopenjdk.net/job/Test_openjdk11_hs_extended.openjdk_x86-64_linux_testList_2/5/) ⚠️ UNSTABLE ⚠️
[jdk_management_1](http://localhost:3000/output/test?id=60e60cdb631d857f69d621d4) => [deep history 0/4 passed](http://localhost:3000/deepHistory?testId=60e60cdb631d857f69d621d4) | [possible issues](http://localhost:3000/possibleIssues?buildId=60e60c00631d857f69d6201c&buildName=Test_openjdk11_hs_extended.openjdk_x86-64_linux_testList_2&testId=60e60cdb631d857f69d621d4&testName=jdk_management_1) 
