### PR TITLE
Add rerun in Grinder link in release summary report

### DIFF
--- a/test-result-summary-client/src/Build/ReleaseSummary.jsx
+++ b/test-result-summary-client/src/Build/ReleaseSummary.jsx
@@ -21,18 +21,19 @@ export default class ReleaseSummary extends Component {
 
         const build = await fetchData(`/api/getParents?id=${parentId}`);
         let report = '';
+        const nl = `\n`;
         if (build && build[0]) {
             const { buildName, buildUrl, timestamp, startBy } = build[0];
             report =
-                `#### Release Summary Report for ${buildName} \n` +
-                `**Report generated at:** ${new Date().toUTCString()} \n \n` +
+                `#### Release Summary Report for ${buildName} ${nl}` +
+                `**Report generated at:** ${new Date().toUTCString()} ${nl} ${nl}` +
                 `TRSS [Build](${originUrl}/buildDetail?parentId=${parentId}&testSummaryResult=failed&buildNameRegex=%5ETest) ` +
-                `and TRSS [Grid View](${originUrl}/resultSummary?parentId=${parentId}) \n` +
-                `Jenkins Build URL ${buildUrl} \nStarted by ${startBy} at ${new Date(
+                `and TRSS [Grid View](${originUrl}/resultSummary?parentId=${parentId}) ${nl}` +
+                `Jenkins Build URL ${buildUrl} ${nl}Started by ${startBy} at ${new Date(
                     timestamp
-                ).toLocaleString()} \n`;
+                ).toLocaleString()} ${nl}`;
 
-            report += '\n --- \n';
+            report += `${nl} --- ${nl}`;
 
             const buildResult = '!SUCCESS';
             const failedBuilds = await fetchData(
@@ -50,11 +51,11 @@ export default class ReleaseSummary extends Component {
                         javaVersion,
                         tests = [],
                     }) => {
-                        const buildInfo = `\n[**${buildName}**](${buildUrl})`;
+                        const buildInfo = `${nl}[**${buildName}**](${buildUrl})`;
                         const buildResultStr =
                             buildResult === 'UNSTABLE'
-                                ? ` ⚠️ ${buildResult} ⚠️\n`
-                                : ` ❌ ${buildResult} ❌\n`;
+                                ? ` ⚠️ ${buildResult} ⚠️${nl}`
+                                : ` ❌ ${buildResult} ❌${nl}`;
                         if (buildName.startsWith('Test_openjdk')) {
                             failedTestSummary[buildName] = buildInfo;
                             failedTestSummary[buildName] += buildResultStr;
@@ -92,7 +93,7 @@ export default class ReleaseSummary extends Component {
                                                         testId,
                                                         testName,
                                                     }
-                                                )}) \n`;
+                                                )}) ${nl}`;
                                         }
                                     }
                                 )
@@ -111,7 +112,7 @@ export default class ReleaseSummary extends Component {
                     .map((buildName) => {
                         report += failedBuildSummary[buildName];
                     });
-                report += '\n --- \n';
+                report += `${nl} --- ${nl}`;
                 Object.keys(failedTestSummary)
                     .sort()
                     .map((buildName) => {

--- a/test-result-summary-client/src/Build/ReleaseSummary.jsx
+++ b/test-result-summary-client/src/Build/ReleaseSummary.jsx
@@ -20,9 +20,16 @@ export default class ReleaseSummary extends Component {
         const originUrl = window.location.origin;
 
         const build = await fetchData(`/api/getParents?id=${parentId}`);
+
         let report = '';
         const nl = `\n`;
         if (build && build[0]) {
+            const buildData = await fetchData(`/api/getData?_id=${parentId}`);
+            let { rerunLink } = buildData ? buildData[0] : null;
+            const rerunLinkInfo = rerunLink
+                ? `Rerun [all](${rerunLink}) ${nl}`
+                : `${nl}`;
+
             const { buildName, buildUrl, timestamp, startBy } = build[0];
             report =
                 `#### Release Summary Report for ${buildName} ${nl}` +
@@ -31,7 +38,8 @@ export default class ReleaseSummary extends Component {
                 `and TRSS [Grid View](${originUrl}/resultSummary?parentId=${parentId}) ${nl}` +
                 `Jenkins Build URL ${buildUrl} ${nl}Started by ${startBy} at ${new Date(
                     timestamp
-                ).toLocaleString()} ${nl}`;
+                ).toLocaleString()} ${nl}` +
+                rerunLinkInfo;
 
             report += `${nl} --- ${nl}`;
 


### PR DESCRIPTION
Updated TRSS Release Summary Report to include rerun in grinder link for the entire build report. This is partial fix of #624 

Fixes: #631 

Signed-off-by: Tommy Tho [tommythowm@gmail.com](mailto:tommythowm@gmail.com)