### PR TITLE
Added `java -version` to the grid view

### DIFF
--- a/test-result-summary-client/src/Build/Summary/Overview.jsx
+++ b/test-result-summary-client/src/Build/Summary/Overview.jsx
@@ -11,7 +11,8 @@ const DAY_FORMAT = 'MMM DD YYYY, hh:mm a';
 
 export default class Overview extends Component {
     render() {
-        const { id, parentBuildInfo, summary, failedSdkBuilds } = this.props;
+        const { id, parentBuildInfo, summary, failedSdkBuilds, javaVersion } =
+            this.props;
         if (id && parentBuildInfo) {
             const {
                 passed = 0,
@@ -50,7 +51,9 @@ export default class Overview extends Component {
                             </Button>
                         </div>
                     </Link>
-                    <Divider>SDK Build Results</Divider>
+                    <Divider style={{ fontSize: '20px' }}>
+                        SDK Build Results
+                    </Divider>
                     <div style={{ fontSize: '18px' }}>
                         {failedSdkBuilds && failedSdkBuilds.length ? (
                             <BuildLink
@@ -65,8 +68,24 @@ export default class Overview extends Component {
                         )}
                     </div>
 
-                    <Divider>AQA Test Results</Divider>
+                    <Divider style={{ fontSize: '20px' }}>
+                        AQA Test Results
+                    </Divider>
                     <div style={{ fontSize: '18px' }}>
+                        <Row>
+                            <Col span={6}>
+                                <Divider>Test Summary</Divider>
+                            </Col>
+                            <Col span={6}>
+                                <Divider>Pass Percentage</Divider>
+                            </Col>
+                            <Col span={6}>
+                                <Divider>Build Result</Divider>
+                            </Col>
+                            <Col span={6}>
+                                <Divider>Build Metadata</Divider>
+                            </Col>
+                        </Row>
                         <Row>
                             <Col span={6}>
                                 <BuildLink
@@ -133,30 +152,32 @@ export default class Overview extends Component {
 
                             <Col span={6}>
                                 <div>
-                                    Build Started at:{' '}
+                                    <strong>Build Started at:</strong>{' '}
                                     {moment(parentBuildInfo.timestamp).format(
                                         DAY_FORMAT
                                     )}
                                 </div>
                                 <div>
-                                    Build Started by: {parentBuildInfo.startBy}
+                                    <strong>Build Started by:</strong>{' '}
+                                    {parentBuildInfo.startBy}
                                 </div>
                                 <div>
-                                    Build Duration:{' '}
+                                    <strong>Build Duration:</strong>{' '}
                                     {renderDuration(
                                         parentBuildInfo.buildDuration
                                     )}
                                 </div>
-                                <div>Machine: {parentBuildInfo.machine}</div>
+                                <div>
+                                    <strong>Machine:</strong>{' '}
+                                    {parentBuildInfo.machine}
+                                </div>
                             </Col>
-                        </Row>
-                        <Row>
-                            <Col span={6} />
+
                             <Col span={6}>
-                                <div>Pass Percentage</div>
-                            </Col>
-                            <Col span={6}>
-                                <div>Build Result</div>
+                                <div>
+                                    <strong>java -version:</strong>{' '}
+                                    {javaVersion}
+                                </div>
                             </Col>
                         </Row>
                     </div>

--- a/test-result-summary-client/src/Build/Summary/ResultSummary.jsx
+++ b/test-result-summary-client/src/Build/Summary/ResultSummary.jsx
@@ -60,10 +60,11 @@ export default class ResultSummary extends Component {
                 parentId,
             })}`
         );
+        let javaVersion = null;
         const buildMap = {};
         let jdkVersionOpts = [];
         let jdkImplOpts = [];
-        builds.map((build, i) => {
+        builds.forEach((build) => {
             const buildName = build.buildName.toLowerCase();
             if (getInfoFromBuildName(buildName)) {
                 const { jdkVersion, jdkImpl, level, group, platform } =
@@ -156,6 +157,10 @@ export default class ResultSummary extends Component {
                     }
                 }
             }
+
+            if (!javaVersion && build.javaVersion) {
+                javaVersion = build.javaVersion;
+            }
         });
         const platformOpts = Object.keys(buildMap).sort();
         jdkVersionOpts = [...new Set(jdkVersionOpts)].sort(order);
@@ -172,6 +177,7 @@ export default class ResultSummary extends Component {
             selectedJdkImpls: jdkImplOpts,
             allJdkImpls: jdkImplOpts,
             failedSdkBuilds,
+            javaVersion,
         });
     }
 
@@ -187,6 +193,7 @@ export default class ResultSummary extends Component {
             summary,
             parentBuildInfo,
             failedSdkBuilds,
+            javaVersion,
         } = this.state;
         const { parentId } = getParams(this.props.location.search);
 
@@ -199,6 +206,7 @@ export default class ResultSummary extends Component {
                         parentBuildInfo={parentBuildInfo}
                         summary={summary}
                         failedSdkBuilds={failedSdkBuilds}
+                        javaVersion={javaVersion}
                     />
                     <Divider />
                     <ResultGrid


### PR DESCRIPTION
Added a `Build Metadata` column to the grid view beside `Build Result` that displays `java -version`.

Includes a couple of fixes to the `ResultSummary.jsx` syntax and aesthetic fixes to the grid view to make it easier to view.

<img width="1181" alt="Screen Shot 2022-04-06 at 3 37 21 PM" src="https://user-images.githubusercontent.com/71192999/162077070-1baec509-69fd-4d45-accf-f6dbdadeb73c.png">

Fixes: #642

Signed-off-by: Nadeen Mohamed <nadeen@ualberta.ca>