### PR TITLE
encode testName in rerun url

### DIFF
--- a/test-result-summary-client/src/Build/ReleaseSummary.jsx
+++ b/test-result-summary-client/src/Build/ReleaseSummary.jsx
@@ -79,16 +79,26 @@ export default class ReleaseSummary extends Component {
                                 tests.map(
                                     async ({ _id, testName, testResult }) => {
                                         if (testResult === 'FAILED') {
-                                            const rerunChildLink = rerunLink
-                                                ? rerunLink.replace(
-                                                      /(\WTARGET=)([^&]*)/gi,
-                                                      '$1' + testName
-                                                  )
-                                                : ``;
-                                            const rerunChildLinkInfo =
-                                                rerunChildLink
-                                                    ? ` | [rerun](${rerunChildLink}) ${nl}`
-                                                    : `${nl}`;
+                                            let rerunChildLinkInfo = `${nl}`;
+                                            if (
+                                                testName !== 'Post Test' &&
+                                                testName !== 'Pre Test'
+                                            ) {
+                                                const encodeTestName =
+                                                    encodeURIComponent(
+                                                        testName
+                                                    );
+                                                const rerunChildLink = rerunLink
+                                                    ? rerunLink.replace(
+                                                          /(\WTARGET=)([^&]*)/gi,
+                                                          '$1' + encodeTestName
+                                                      )
+                                                    : ``;
+                                                if (rerunChildLink) {
+                                                    rerunChildLinkInfo = ` | [rerun](${rerunChildLink}) ${nl}`;
+                                                }
+                                            }
+
                                             const testId = _id;
                                             const history = await fetchData(
                                                 `/api/getHistoryPerTest?testId=${testId}&limit=100`


### PR DESCRIPTION
- encode testName in rerun url
- no rerun link for Post Test and Pre Test as they are artificial test targets

Fix: https://github.com/adoptium/aqa-test-tools/issues/658

Signed-off-by: lanxia <lan_xia@ca.ibm.com>