### PR TITLE
Display warning message in Grid view

### DIFF
--- a/test-result-summary-client/src/Build/Summary/Overview.jsx
+++ b/test-result-summary-client/src/Build/Summary/Overview.jsx
@@ -11,7 +11,7 @@ const DAY_FORMAT = 'MMM DD YYYY, hh:mm a';
 
 export default class Overview extends Component {
     render() {
-        const { id, parentBuildInfo, summary, failedSdkBuilds, javaVersion } =
+        const { id, parentBuildInfo, summary, sdkBuilds, javaVersion } =
             this.props;
         if (id && parentBuildInfo) {
             const {
@@ -52,25 +52,35 @@ export default class Overview extends Component {
                         </div>
                     </Link>
                     <Divider style={{ fontSize: '20px' }}>
-                        SDK Build Results
+                        Build and AQA Test Results
                     </Divider>
                     <div style={{ fontSize: '18px' }}>
-                        {failedSdkBuilds && failedSdkBuilds.length ? (
-                            <BuildLink
-                                id={id}
-                                label="SDK Builds and Smoke Tests "
-                                link="Failed"
-                                buildNameRegex="^(jdk[0-9]{1,2}|Build_)"
-                                buildResult="!SUCCESS"
-                            />
+                        {sdkBuilds && sdkBuilds.length === 0 ? (
+                            <div>
+                                <b>Warning</b>: No JDK Builds get triggered in
+                                this pipeline. Please check TRSS{' '}
+                                <Link
+                                    to={{
+                                        pathname: '/buildDetail',
+                                        search: params({ parentId: id }),
+                                    }}
+                                    target="_blank"
+                                >
+                                    build details
+                                </Link>{' '}
+                                or Jenkins{' '}
+                                <a
+                                    href={parentBuildInfo.buildUrl}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                >
+                                    {buildName} #{parentBuildInfo.buildNum}
+                                </a>
+                            </div>
                         ) : (
-                            <div>SDK builds and Smoke Tests Passed</div>
+                            <div />
                         )}
                     </div>
-
-                    <Divider style={{ fontSize: '20px' }}>
-                        AQA Test Results
-                    </Divider>
                     <div style={{ fontSize: '18px' }}>
                         <Row>
                             <Col span={6}>

--- a/test-result-summary-client/src/Build/Summary/ResultSummary.jsx
+++ b/test-result-summary-client/src/Build/Summary/ResultSummary.jsx
@@ -29,7 +29,7 @@ export default class ResultSummary extends Component {
         allJdkVersions: [],
         selectedJdkImpls: [],
         allJdkImpls: [],
-        failedSdkBuilds: [],
+        sdkBuilds: [],
     };
     async componentDidMount() {
         await this.updateData();
@@ -44,16 +44,6 @@ export default class ResultSummary extends Component {
         // get build information
         const buildInfo = await fetchData(`/api/getData?_id=${parentId}`);
         const parentBuildInfo = buildInfo[0] || {};
-
-        // get failed SDK build
-        // need to support different SDK build names: jdk8u-linux-aarch64-openj9 and Build_JDK8_ppc64_aix_Nightly
-        const failedSdkBuilds = await fetchData(
-            `/api/getAllChildBuilds${params({
-                buildResult: '!SUCCESS',
-                buildNameRegex: '^(jdk[0-9]{1,2}|Build_)',
-                parentId,
-            })}`
-        );
 
         // get all SDK builds info
         const sdkBuilds = await fetchData(
@@ -266,7 +256,7 @@ export default class ResultSummary extends Component {
             allJdkVersions: jdkVersionOpts,
             selectedJdkImpls: jdkImplOpts,
             allJdkImpls: jdkImplOpts,
-            failedSdkBuilds,
+            sdkBuilds,
             javaVersion,
         });
     }
@@ -282,7 +272,7 @@ export default class ResultSummary extends Component {
             allJdkImpls,
             summary,
             parentBuildInfo,
-            failedSdkBuilds,
+            sdkBuilds,
             javaVersion,
         } = this.state;
         const { parentId } = getParams(this.props.location.search);
@@ -295,7 +285,7 @@ export default class ResultSummary extends Component {
                         id={parentId}
                         parentBuildInfo={parentBuildInfo}
                         summary={summary}
-                        failedSdkBuilds={failedSdkBuilds}
+                        sdkBuilds={sdkBuilds}
                         javaVersion={javaVersion}
                     />
                     <Divider />


### PR DESCRIPTION
- Remove SDK Build Results section
- Rename AQA Test Results section name to Build and AQA Test Results
- Display the warning message if no JDK build job gets triggered

Resovles: https://github.com/adoptium/aqa-test-tools/issues/665

Signed-off-by: lanxia <lan_xia@ca.ibm.com>