### PR TITLE
Remove rerun link for each failed test

### DIFF
--- a/test-result-summary-client/src/Build/ReleaseSummary.jsx
+++ b/test-result-summary-client/src/Build/ReleaseSummary.jsx
@@ -81,26 +81,6 @@ export default class ReleaseSummary extends Component {
                                 tests.map(
                                     async ({ _id, testName, testResult }) => {
                                         if (testResult === 'FAILED') {
-                                            let rerunChildLinkInfo = `${nl}`;
-                                            if (
-                                                testName !== 'Post Test' &&
-                                                testName !== 'Pre Test'
-                                            ) {
-                                                const encodeTestName =
-                                                    encodeURIComponent(
-                                                        testName
-                                                    );
-                                                const rerunChildLink = rerunLink
-                                                    ? rerunLink.replace(
-                                                          /(\WTARGET=)([^&]*)/gi,
-                                                          '$1' + encodeTestName
-                                                      )
-                                                    : ``;
-                                                if (rerunChildLink) {
-                                                    rerunChildLinkInfo = ` | [rerun](${rerunChildLink}) ${nl}`;
-                                                }
-                                            }
-
                                             const testId = _id;
                                             const history = await fetchData(
                                                 `/api/getHistoryPerTest?testId=${testId}&limit=100`
@@ -124,7 +104,7 @@ export default class ReleaseSummary extends Component {
                                                         testId,
                                                         testName,
                                                     }
-                                                )})${rerunChildLinkInfo}`;
+                                                )})${nl}`;
                                         }
                                     }
                                 )


### PR DESCRIPTION
Related: https://github.com/adoptium/aqa-test-tools/issues/684

Signed-off-by: lanxia <lan_xia@ca.ibm.com>