### PR TITLE
Add --legacy-peer-deps for npm

### DIFF
--- a/TestResultSummaryService/jenkins/trssCodeSync.groovy
+++ b/TestResultSummaryService/jenkins/trssCodeSync.groovy
@@ -15,8 +15,8 @@ node(TRSS_NODE) {
 			git pull
 			echo "Update TRSS client..."
 			cd test-result-summary-client
-			echo "npm ci --production"
-			npm ci --production
+			echo "npm ci --production --legacy-peer-deps"
+			npm ci --production --legacy-peer-deps
 			echo "npm run build"
 			CI=false npm run build
 			echo "Update TRSS server..."


### PR DESCRIPTION
With newer version of npm, it tries to download the peer dependencies by default.
While doing so, it complains that we have conflicting peer dependency that can not be resolved in highcharts.
Since forcing update may introduce breaking changes, set --legacy-peer-deps to ignore this requirement.

Signed-off-by: lanxia <lan_xia@ca.ibm.com>