### PR TITLE
Update the test parser logic and add API rate limit

### DIFF
--- a/TestResultSummaryService/README.md
+++ b/TestResultSummaryService/README.md
@@ -4,7 +4,7 @@ Project for logging test results and viewing history. Should be abstract enough 
 
 ## Prerequisites
 
--   Node Version: 11.4.0 [Install Node](https://nodejs.org/en/download/)
+-   Node Version: 16+ [Install Node](https://nodejs.org/en/download/)
 -   System Dependencies: npm (comes packaged with Node)
 -   MongoDB 4.0.6 and above
 -   Access to [Jenkins Instances](https://ci.adoptopenjdk.net)

--- a/TestResultSummaryService/frontend.js
+++ b/TestResultSummaryService/frontend.js
@@ -9,12 +9,21 @@ const routes = require('./routes');
 const compression = require('compression');
 const { logger } = require('./Utils');
 const expressSwagger = require('express-swagger-generator')(app);
+const rateLimit = require('express-rate-limit');
 
 app.use(compression()); // GZIP all assets
 app.use(cors());
 app.use(bodyParser.urlencoded({ extended: true })); // support encoded bodies
 app.use(bodyParser.json()); // support json encoded bodies
 
+const apiLimiter = rateLimit({
+    windowMs: 1 * 60 * 1000, // 1 minutes
+    max: 1000, // Limit each IP to 1000 requests per `window`
+    standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
+    legacyHeaders: false, // Disable the `X-RateLimit-*` headers
+});
+
+app.use('/api', apiLimiter);
 app.use('/api', routes);
 
 let options = {

--- a/TestResultSummaryService/package-lock.json
+++ b/TestResultSummaryService/package-lock.json
@@ -18,6 +18,7 @@
                 "cors": "^2.8.5",
                 "csv": "^5.5.0",
                 "express": "^4.17.1",
+                "express-rate-limit": "^6.6.0",
                 "express-swagger-generator": "^1.1.17",
                 "got": "^11.8.5",
                 "jenkins-api": "^0.3.1",
@@ -1178,6 +1179,17 @@
             },
             "engines": {
                 "node": ">= 0.10.0"
+            }
+        },
+        "node_modules/express-rate-limit": {
+            "version": "6.6.0",
+            "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-6.6.0.tgz",
+            "integrity": "sha512-HFN2+4ZGdkQOS8Qli4z6knmJFnw6lZed67o6b7RGplWeb1Z0s8VXaj3dUgPIdm9hrhZXTRpCTHXA0/2Eqex0vA==",
+            "engines": {
+                "node": ">= 12.9.0"
+            },
+            "peerDependencies": {
+                "express": "^4 || ^5"
             }
         },
         "node_modules/express-swagger-generator": {
@@ -5146,6 +5158,12 @@
                     "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
                 }
             }
+        },
+        "express-rate-limit": {
+            "version": "6.6.0",
+            "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-6.6.0.tgz",
+            "integrity": "sha512-HFN2+4ZGdkQOS8Qli4z6knmJFnw6lZed67o6b7RGplWeb1Z0s8VXaj3dUgPIdm9hrhZXTRpCTHXA0/2Eqex0vA==",
+            "requires": {}
         },
         "express-swagger-generator": {
             "version": "1.1.17",

--- a/TestResultSummaryService/package.json
+++ b/TestResultSummaryService/package.json
@@ -29,6 +29,7 @@
         "cors": "^2.8.5",
         "csv": "^5.5.0",
         "express": "^4.17.1",
+        "express-rate-limit": "^6.6.0",
         "express-swagger-generator": "^1.1.17",
         "got": "^11.8.5",
         "jenkins-api": "^0.3.1",

--- a/TestResultSummaryService/parsers/Test.js
+++ b/TestResultSummaryService/parsers/Test.js
@@ -1,8 +1,6 @@
 const Parser = require('./Parser');
-//const regexRunningTest =
-//    /.*?===============================================\r?\n.*?Running test (.*?) \.\.\.\r?\n.*?===============================================\r?\n/;
 const regexRunningTest = /.*?Running test (.*?) \.\.\.\r?/;
-const testSeparator = /.*?===============================================\r?\n/;
+const testSeparator = /.*?===============================================\r?/;
 const regexFinishTime = /(.*?) Finish Time\: .* Epoch Time \(ms\)\: (\d+).*/;
 const regexStartTime = /(.*?) Start Time\: .* Epoch Time \(ms\)\: (\d+).*/;
 const TestBenchmarkParser = require(`./TestBenchmarkParser`);
@@ -65,7 +63,6 @@ class Test extends Parser {
         let testStartLine = -1;
         let lineCounter = 0;
         for await (const line of rl) {
-            console.log(lineCounter, line);
             lineCounter++;
             if ((m = line.match(testSeparator)) !== null) {
                 testStartLine = lineCounter;

--- a/TestResultSummaryService/parsers/Test.js
+++ b/TestResultSummaryService/parsers/Test.js
@@ -1,5 +1,8 @@
 const Parser = require('./Parser');
+//const regexRunningTest =
+//    /.*?===============================================\r?\n.*?Running test (.*?) \.\.\.\r?\n.*?===============================================\r?\n/;
 const regexRunningTest = /.*?Running test (.*?) \.\.\.\r?/;
+const testSeparator = /.*?===============================================\r?\n/;
 const regexFinishTime = /(.*?) Finish Time\: .* Epoch Time \(ms\)\: (\d+).*/;
 const regexStartTime = /(.*?) Start Time\: .* Epoch Time \(ms\)\: (\d+).*/;
 const TestBenchmarkParser = require(`./TestBenchmarkParser`);
@@ -59,8 +62,17 @@ class Test extends Parser {
         let nonTestStr = '';
         let preTestDone = false;
         let postTestDone = false;
+        let testStartLine = -1;
+        let lineCounter = 0;
         for await (const line of rl) {
-            if ((m = line.match(regexRunningTest)) !== null) {
+            console.log(lineCounter, line);
+            lineCounter++;
+            if ((m = line.match(testSeparator)) !== null) {
+                testStartLine = lineCounter;
+            } else if (
+                lineCounter === testStartLine + 1 &&
+                (m = line.match(regexRunningTest)) !== null
+            ) {
                 if (!preTestDone) {
                     results.push({
                         testName: preTest,

--- a/TestResultSummaryService/routes/index.js
+++ b/TestResultSummaryService/routes/index.js
@@ -44,7 +44,11 @@ app.get('/getTotals', wrap(require('./getTotals')));
 app.get('/parseJenkinsUrl', wrap(require('./parseJenkinsUrl')));
 app.get('/populateDB', wrap(require('./populateDB')));
 app.get('/getFeedbackUrl', wrap(require('./getFeedbackUrl')));
-app.get('/testParser', wrap(require('./test/testParser')));
+app.get('/testParserViaFile', wrap(require('./test/testParserViaFile')));
+app.get(
+    '/testParserViaLogStream',
+    wrap(require('./test/testParserViaLogStream'))
+);
 
 app.get('/updateComments', wrap(require('./updateComments')));
 app.get('/updateKeepForever', wrap(require('./updateKeepForever')));

--- a/TestResultSummaryService/routes/test/testParserViaFile.js
+++ b/TestResultSummaryService/routes/test/testParserViaFile.js
@@ -1,11 +1,9 @@
 const fs = require('fs').promises;
 const DataManager = require('../../DataManager');
 module.exports = async (req, res) => {
-    let { file, buildName } = req.query;
-    if (!buildName)
-        buildName =
-            'Test_openjdk17_j9_sanity.functional_aarch64_mac_testList_2';
-    if (!file) file = 'jobOutput.txt';
+    const buildName =
+        'Test_openjdk17_j9_sanity.functional_aarch64_mac_testList_2';
+    let file = 'jobOutput.txt';
     file = `${__dirname}/${file}`;
 
     try {

--- a/TestResultSummaryService/routes/test/testParserViaLogStream.js
+++ b/TestResultSummaryService/routes/test/testParserViaLogStream.js
@@ -1,0 +1,17 @@
+const LogStream = require('../../LogStream');
+const DataManager = require('../../DataManager');
+module.exports = async (req, res) => {
+    const { url, buildName, buildNum } = req.query;
+    try {
+        const logStream = new LogStream({
+            baseUrl: url,
+            job: buildName,
+            build: parseInt(buildNum, 10),
+        });
+        const output = await logStream.next(0);
+        const data = await new DataManager().parseOutput(buildName, output);
+        res.send({ result: output, data });
+    } catch (e) {
+        res.send({ result: e.toString() });
+    }
+};


### PR DESCRIPTION
- Update the test parser logic to resolve the problem in https://github.com/adoptium/aqa-tests/issues/3792#issuecomment-1164482604
- Add API rate limit to avoid large number of repeated queries to our public APIs
- Add test for testing parser
- Update readme - Node version should be 16+

Related: https://github.com/adoptium/aqa-tests/issues/3792

Signed-off-by: lanxia <lan_xia@ca.ibm.com>