### PR TITLE
Add option to connect Adoptium TRSS API

### DIFF
--- a/test-result-summary-client/.npmrc
+++ b/test-result-summary-client/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/test-result-summary-client/src/utils/Utils.js
+++ b/test-result-summary-client/src/utils/Utils.js
@@ -50,7 +50,11 @@ const getSHA = (type, javaVersion) => {
     return null;
 };
 
+const connectAdoptiumAPI = process.env.REACT_APP_CONNECT_ADOPTIUM_API;
 export const fetchData = async (url) => {
+    if (connectAdoptiumAPI) {
+        url = 'https://trss.adoptium.net' + url;
+    }
     try {
         const response = await fetch(url, {
             method: 'get',


### PR DESCRIPTION
- Add option to connect Adoptium TRSS API for PR testing (i.e., Netlify)
- Set npm default option in .npmrc

Related: https://github.com/adoptium/aqa-test-tools/issues/593

Signed-off-by: lanxia <lan_xia@ca.ibm.com>