### PR TITLE
initial AzDo port to support perf compare

### DIFF
--- a/TestResultSummaryService/routes/getAzDoRun.js
+++ b/TestResultSummaryService/routes/getAzDoRun.js
@@ -1,0 +1,232 @@
+const request = require('request');
+const Parsers = require('../parsers');
+const DefaultParser = require('../parsers/Default');
+const DataManagerAggregate = require('../perf/DataManagerAggregate');
+const ArgParser = require('../ArgParser');
+const math = require('mathjs');
+const BenchmarkMath = require('../perf/BenchmarkMathCalculation');
+
+module.exports = async (req, res) => {
+    const { user, password, server } =
+        ArgParser.getConfig() === undefined ? {} : ArgParser.getConfig().AzDo;
+
+    // extract buildId from url
+    const buildId = req.query.buildId;
+
+    const auth = {
+        user,
+        password,
+    };
+
+    // Fetch job details from the Azure Devops api
+    request.get(
+        server + '/_apis/build/builds/' + buildId,
+        {
+            auth: auth,
+        },
+        function (err, body) {
+            if (err) {
+                return res.json({ error: err });
+            }
+            const buildInfo = JSON.parse(body.body);
+            let benchmarkVariant = buildInfo.templateParameters.suite;
+            const startTime = new Date(buildInfo.startTime).toLocaleString();
+
+            // extract benchmark name from benchmarkVariant
+            let benchmarkName;
+            switch (true) {
+                case benchmarkVariant.includes('specjbb'):
+                    benchmarkName = 'SPECjbb2015';
+                    break;
+                default:
+                    benchmarkName = benchmarkVariant;
+            }
+
+            // fetch the timeline
+            request.get(
+                server + '/_apis/build/builds/' + buildId + '/timeline',
+                {
+                    auth: auth,
+                },
+                function (err, body) {
+                    if (err) {
+                        return res.json({ error: err });
+                    }
+                    const results = JSON.parse(body.body);
+                    // extract worker name from timeline
+                    const agentName = results.records.find(
+                        (job) =>
+                            job.name ===
+                            `Run ${buildInfo.templateParameters.suite}`
+                    ).workerName;
+                    // find the log with the name of the benchmark
+                    const logURL = results.records.find(
+                        (job) =>
+                            job.name ===
+                            `Run ${buildInfo.templateParameters.suite}`
+                    ).log.url;
+                    // fetch the log
+                    request.get(
+                        logURL,
+                        {
+                            auth: auth,
+                        },
+                        async function (err, body) {
+                            if (err) {
+                                return res.json({ error: err });
+                            }
+                            const log = body.body;
+
+                            const parserTypes = await Promise.all(
+                                Object.keys(Parsers).map(async (type) => {
+                                    if (
+                                        Parsers[type].canParse(
+                                            benchmarkName,
+                                            log
+                                        )
+                                    ) {
+                                        const parser = new Parsers[type](
+                                            benchmarkName
+                                        );
+                                        return await parser.parse(log);
+                                    }
+                                })
+                            );
+
+                            let results = parserTypes.filter((element) => {
+                                return element !== undefined;
+                            });
+
+                            if (results.length === 0) {
+                                const parser = new DefaultParser();
+                                results = await parser.parse(log);
+                            }
+
+                            // fetch aggregate data
+                            const aggRawMetricValues =
+                                DataManagerAggregate.aggDataCollect(results[0]);
+
+                            const aggregateInfo = [];
+
+                            if (
+                                aggRawMetricValues &&
+                                Object.keys(aggRawMetricValues).length > 0
+                            ) {
+                                Object.keys(aggRawMetricValues).forEach(
+                                    function (name_variant) {
+                                        benchmarkName =
+                                            name_variant.split('&&')[0];
+                                        benchmarkVariant =
+                                            name_variant.split('&&')[1];
+                                        const metrics = [];
+                                        let benchmarkMetricsCollection =
+                                            aggRawMetricValues[name_variant];
+                                        Object.keys(
+                                            benchmarkMetricsCollection
+                                        ).forEach(function (key) {
+                                            if (
+                                                Array.isArray(
+                                                    benchmarkMetricsCollection[
+                                                        key
+                                                    ]
+                                                ) &&
+                                                benchmarkMetricsCollection[key]
+                                                    .length > 0
+                                            ) {
+                                                const mean = math.round(
+                                                    math.mean(
+                                                        benchmarkMetricsCollection[
+                                                            key
+                                                        ]
+                                                    ),
+                                                    3
+                                                );
+                                                const max = math.round(
+                                                    math.max(
+                                                        benchmarkMetricsCollection[
+                                                            key
+                                                        ]
+                                                    ),
+                                                    3
+                                                );
+                                                const min = math.round(
+                                                    math.min(
+                                                        benchmarkMetricsCollection[
+                                                            key
+                                                        ]
+                                                    ),
+                                                    3
+                                                );
+                                                const median = math.round(
+                                                    math.median(
+                                                        benchmarkMetricsCollection[
+                                                            key
+                                                        ]
+                                                    ),
+                                                    3
+                                                );
+                                                const stddev = math.round(
+                                                    math.std(
+                                                        benchmarkMetricsCollection[
+                                                            key
+                                                        ]
+                                                    ),
+                                                    3
+                                                );
+                                                const CI = math.round(
+                                                    BenchmarkMath.confidence_interval(
+                                                        benchmarkMetricsCollection[
+                                                            key
+                                                        ]
+                                                    ),
+                                                    3
+                                                );
+                                                metrics.push({
+                                                    name: key,
+                                                    statValues: {
+                                                        mean,
+                                                        max,
+                                                        min,
+                                                        median,
+                                                        stddev,
+                                                        CI,
+                                                        validIterations:
+                                                            benchmarkMetricsCollection[
+                                                                key
+                                                            ].length,
+                                                    },
+                                                    rawValues:
+                                                        benchmarkMetricsCollection[
+                                                            key
+                                                        ],
+                                                });
+                                            }
+                                        });
+                                        //add aggregate info for each node and update it in both parent and child node database
+                                        aggregateInfo.push({
+                                            benchmarkName,
+                                            benchmarkVariant,
+                                            metrics,
+                                        });
+                                    }
+                                );
+                            }
+
+                            for (const result of results) {
+                                result.startBy =
+                                    buildInfo.requestedBy.displayName;
+                                result.machine = agentName;
+                                result.jdkDate = startTime;
+                                result.javaVersion =
+                                    buildInfo.templateParameters.javaVersion;
+                                result.aggregateInfo = aggregateInfo;
+                            }
+
+                            return res.json(results);
+                        }
+                    );
+                }
+            );
+        }
+    );
+};

--- a/TestResultSummaryService/routes/index.js
+++ b/TestResultSummaryService/routes/index.js
@@ -31,6 +31,7 @@ app.get('/getOutputById', wrap(require('./getOutputById')));
 app.get('/getOutputByTestInfo', wrap(require('./getOutputByTestInfo')));
 app.get('/getTestAvgDuration', wrap(require('./getTestAvgDuration')));
 app.get('/getTestInfoByBuildInfo', wrap(require('./getTestInfoByBuildInfo')));
+app.get('/getAzDoRun', wrap(require('./getAzDoRun')));
 app.get('/getParents', wrap(require('./getParents')));
 app.get('/getPerffarmRunCSV', wrap(require('./getPerffarmRunCSV')));
 app.get('/getTabularData', wrap(require('./getTabularData')));

--- a/test-result-summary-client/src/PerfCompare/lib/AzDoRunJSON.js
+++ b/test-result-summary-client/src/PerfCompare/lib/AzDoRunJSON.js
@@ -1,0 +1,42 @@
+export default class AzDoRunJSON {
+    constructor(runJSON) {
+        this.runJSON = runJSON;
+        this.parsedVariants = [];
+    }
+
+    init(callback) {
+        let parsedVariantsCommon = {};
+        let curVariantObjectId = null;
+
+        const { jdkDate, machine, aggregateInfo } = this.runJSON[0];
+
+        if (Array.isArray(aggregateInfo) && aggregateInfo.length > 0) {
+            for (let {
+                benchmarkName,
+                benchmarkVariant,
+                metrics,
+            } of aggregateInfo) {
+                if (benchmarkName && benchmarkVariant) {
+                    curVariantObjectId =
+                        benchmarkName + '!@#$%DELIMIT%$#@!' + benchmarkVariant;
+                }
+                // new variant
+                if (!parsedVariantsCommon[curVariantObjectId]) {
+                    parsedVariantsCommon[curVariantObjectId] = {
+                        jdkDate,
+                        benchmarkName,
+                        benchmarkVariant,
+                        machine,
+                        metrics,
+                    };
+                    this.parsedVariants.push(
+                        parsedVariantsCommon[curVariantObjectId]
+                    );
+                }
+            }
+        }
+
+        //pass a function pointer as a callback
+        callback.bind(this)();
+    }
+}


### PR DESCRIPTION
This is step 1 of porting TRSS to work with Azure Devops.

For now, this will only support the perf compare feature which takes two Azure DevOps URL's and scrapes the metrics using the built-in TRSS parsers.

At some point as a next step I'd like to get the runs imported into the DB but I'd prefer to do this in a follow-up PR to avoid a single massive changeset.