### PR TITLE
Add getBuildStages API

### DIFF
--- a/TestResultSummaryService/JenkinsApiQuery.js
+++ b/TestResultSummaryService/JenkinsApiQuery.js
@@ -1,0 +1,36 @@
+const got = require('got');
+const url = require('url');
+const { logger, addCredential } = require('./Utils');
+const ArgParser = require('./ArgParser');
+
+class JenkinsApiQuery {
+    constructor(options) {
+        this.credentails = ArgParser.getConfig();
+        const build = options.build || 'lastBuild';
+        this.url =
+            addCredential(this.credentails, options.baseUrl) +
+            '/job/' +
+            options.job +
+            '/' +
+            build +
+            '/';
+    }
+
+    async getBuildStages() {
+        const wfapi = this.url + 'wfapi/describe';
+        logger.debug(
+            `JenkinsApiQuery: getStages(): [CIServerRequest] url: ${wfapi}`
+        );
+        const response = await got.get(wfapi, {
+            followRedirect: true,
+            timeout: 1 * 60 * 1000,
+        });
+        if (response.body.length === 0) {
+            return '';
+        } else {
+            return response.body;
+        }
+    }
+}
+
+module.exports = JenkinsApiQuery;

--- a/TestResultSummaryService/routes/getBuildStages.js
+++ b/TestResultSummaryService/routes/getBuildStages.js
@@ -1,0 +1,25 @@
+const JenkinsApiQuery = require('../JenkinsApiQuery');
+
+/**
+ * getBuildStages query Jenkins via REST API
+ *
+ * @route GET /api/getBuildStages
+ * @param {string} url Required. Jenkins server url (it is used to identify the build).
+ * @param {string} buildName Required.
+ * @param {string} buildNum Required.
+ */
+
+module.exports = async (req, res) => {
+    const { url, buildName, buildNum } = req.query;
+    try {
+        const jenkinsApiQuery = new JenkinsApiQuery({
+            baseUrl: url,
+            job: buildName,
+            build: parseInt(buildNum, 10),
+        });
+        const output = await jenkinsApiQuery.getBuildStages();
+        res.send(output);
+    } catch (e) {
+        res.send({ result: e.toString() });
+    }
+};

--- a/TestResultSummaryService/routes/index.js
+++ b/TestResultSummaryService/routes/index.js
@@ -19,6 +19,7 @@ app.get('/getAuditLogs', wrap(require('./getAuditLogs')));
 app.get('/getBenchmarkMetricProps', wrap(require('./getBenchmarkMetricProps')));
 app.get('/getBuildHistory', wrap(require('./getBuildHistory')));
 app.get('/getBuildList', wrap(require('./getBuildList')));
+app.get('/getBuildStages', wrap(require('./getBuildStages')));
 app.get('/getChildBuilds', wrap(require('./getChildBuilds')));
 app.get('/getDashboardBuildInfo', wrap(require('./getDashboardBuildInfo')));
 app.get('/getData', wrap(require('./getData')));


### PR DESCRIPTION
This is the first step of resolve #777. In this PR, we build the structure to call Jenkins API (using getBuildStages as an example). In the future PR, we will insert the stage info into DB, so that we can analyze all build stages info.

related: https://github.com/adoptium/aqa-test-tools/issues/777