### PR TITLE
Update build retry logic

### DIFF
--- a/TestResultSummaryService/DataManager.js
+++ b/TestResultSummaryService/DataManager.js
@@ -111,7 +111,14 @@ class DataManager {
     }
 
     async updateBuild(data) {
-        logger.verbose('updateBuild', data.buildName, data.buildNum);
+        if (data.buildUrl) {
+            logger.verbose('updateBuild', data.buildUrl);
+        } else if (data.buildName) {
+            logger.verbose('updateBuild', data.buildName, data.buildNum);
+        } else {
+            logger.verbose('updateBuild', data._id);
+        }
+
         const { _id, buildName, ...newData } = data;
         const criteria = { _id: new ObjectID(_id) };
         const testResults = new TestResultsDB();

--- a/TestResultSummaryService/routes/index.js
+++ b/TestResultSummaryService/routes/index.js
@@ -26,6 +26,7 @@ app.get('/getData', wrap(require('./getData')));
 app.get('/getErrorInOutput', wrap(require('./getErrorInOutput')));
 app.get('/getHistoryPerTest', wrap(require('./getHistoryPerTest')));
 app.get('/getJenkins', wrap(require('./getJenkins')));
+app.get('/getJenkinsBuildInfo', wrap(require('./test/getJenkinsBuildInfo')));
 app.get('/getLastBuildInfo', wrap(require('./getLastBuildInfo')));
 app.get('/getLogStream', wrap(require('./getLogStream')));
 app.get('/getOutputById', wrap(require('./getOutputById')));

--- a/TestResultSummaryService/routes/test/getJenkinsBuildInfo.js
+++ b/TestResultSummaryService/routes/test/getJenkinsBuildInfo.js
@@ -1,0 +1,14 @@
+const JenkinsInfo = require('../../JenkinsInfo');
+
+module.exports = async (req, res) => {
+    const { url, buildName, buildNum } = req.query;
+    if (req.query.buildNum)
+        req.query.buildNum = parseInt(req.query.buildNum, 10);
+    const jenkinsInfo = new JenkinsInfo();
+    try {
+        const output = await jenkinsInfo.getBuildInfo(url, buildName, buildNum);
+        res.send({ output });
+    } catch (e) {
+        res.send({ result: e.toString() });
+    }
+};


### PR DESCRIPTION
When querying a build, TRSS will retry 3 times.
In the case of an error, the build will move back to the queue if the return code from Jenkins API is not 404. 
If the return code is 404, x-jenkins header is checked to ensure the error code is from Jenkins (not nginx). 
In this case, it means the build has an invalid url or is expired. retry function returns 404 and TRSS will stop processing this build. 
Otherwise, the error will be ignored (network issue) and the build will move back to the queue.

- sleep is removed to increase efficiency and reliability. We will check the header in the response to determine the invalid/expired build case.
- test API getJenkinsBuildInfo is added
- fix log issue

related: https://github.com/adoptium/aqa-test-tools/issues/852