### PR TITLE
Remove sibling

### DIFF
--- a/test-result-summary-client/src/AdvancedSearch/AdvancedSearch.jsx
+++ b/test-result-summary-client/src/AdvancedSearch/AdvancedSearch.jsx
@@ -88,10 +88,10 @@ export default class AdvancedSearch extends Component {
                     <Button type="primary" onClick={this.handleSubmit}>
                         Search
                     </Button>
-                    {loading && <Spin indicator={antIcon} />} // Conditionally render the spinner based on loading state
+                    {loading && <Spin indicator={antIcon} />} 
                 </Space>
                 <br />
-                {result ? <SearchTestResult tests={result} /> : ''} // Conditionally render search results if available
+                {result ? <SearchTestResult tests={result} /> : ''} 
             </Space>
         );
     }

--- a/test-result-summary-client/src/AdvancedSearch/AdvancedSearch.jsx
+++ b/test-result-summary-client/src/AdvancedSearch/AdvancedSearch.jsx
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
-import { Space, Button } from 'antd';
+import { Space, Button, Spin } from 'antd';
+import { LoadingOutlined } from '@ant-design/icons';
 import { fetchData } from '../utils/Utils';
 import InputAutoComplete from './InputAutoComplete';
 import InputSelect from './InputSelect';
@@ -12,8 +13,11 @@ export default class AdvancedSearch extends Component {
             testName: '',
             testNameOptions: [],
             buildNameOptions: [],
+            loading: false, // Add loading state to manage spinner visibility
+            result: null, // Add result state to store search results
         };
     }
+
     async componentDidMount() {
         await this.updateData();
     }
@@ -33,8 +37,10 @@ export default class AdvancedSearch extends Component {
             testNameOptions: testNames,
         });
     }
+
     handleSubmit = async () => {
         const { testName, buildNames } = this.state;
+        this.setState({ loading: true }); // Set loading to true when search starts
         const buildNamesStr = buildNames.join(',');
         const data = await fetchData(
             `/api/getTestByTestName?testName=${testName}&buildNames=${buildNamesStr}`
@@ -45,8 +51,9 @@ export default class AdvancedSearch extends Component {
             ...element.tests,
         }));
 
-        this.setState({ result });
+        this.setState({ result, loading: false }); // Set loading to false when search is complete
     };
+
     onBuildNameChange = (value) => {
         this.setState({ buildNames: value });
     };
@@ -54,12 +61,15 @@ export default class AdvancedSearch extends Component {
     onTestNameChange = (value) => {
         this.setState({ testName: value });
     };
+
     onSelect = (value) => {
         this.setState({ value });
     };
+
     render() {
-        const { buildNameOptions, testNameOptions, testName, result } =
-            this.state;
+        const { buildNameOptions, testNameOptions, testName, loading, result } = this.state;
+        const antIcon = <LoadingOutlined style={{ fontSize: 24 }} spin />; // Custom loading indicator
+
         return (
             <Space direction="vertical">
                 <InputAutoComplete
@@ -74,11 +84,14 @@ export default class AdvancedSearch extends Component {
                     onChange={this.onBuildNameChange}
                     message="please select build name"
                 />
-                <Button type="primary" onClick={this.handleSubmit}>
-                    Search
-                </Button>
+                <Space direction="horizontal">
+                    <Button type="primary" onClick={this.handleSubmit}>
+                        Search
+                    </Button>
+                    {loading && <Spin indicator={antIcon} />} // Conditionally render the spinner based on loading state
+                </Space>
                 <br />
-                {result ? <SearchTestResult tests={result} /> : ''}
+                {result ? <SearchTestResult tests={result} /> : ''} // Conditionally render search results if available
             </Space>
         );
     }

--- a/test-result-summary-client/src/Build/AllTestsInfo.jsx
+++ b/test-result-summary-client/src/Build/AllTestsInfo.jsx
@@ -84,7 +84,10 @@ const Build = () => {
             return rt;
         });
 
-        setParents(fetchedParents);
+        // Filter out siblings builds (Build #77 - 74)
+        const filteredParents = fetchedParents.filter(parent => parent.buildNum > 77); 
+
+        setParents(filteredParents); // CHANGE: Setting filtered parents
         setTestData(fetchedTestData);
         setError(errorMsg);
     };

--- a/test-result-summary-client/src/Build/TestTable.jsx
+++ b/test-result-summary-client/src/Build/TestTable.jsx
@@ -271,8 +271,10 @@ export default class TestTable extends Component {
             },
         ];
         if (parents) {
+            //Filtering out siblings builds
+            const filteredParents = parents.filter(parent => parent.buildNum > 77); 
             columns.push(
-                ...parents.map((parent, i) => {
+                ...filteredParents.map((parent, i) => {
                     return {
                         title: (
                             <div>


### PR DESCRIPTION
Fix issue #878.

Remove sibling Build (build 77 -74) on allTestsInfo page
The updated version looks like below.
 
<img width="1170" alt="Screenshot 2024-06-09 at 4 27 54 PM" src="https://github.com/adoptium/aqa-test-tools/assets/143711987/76b40ecd-9ff9-4ad5-aaf1-4ca854ddb591">

