### PR TITLE
Removing the Remove sibling Build on allTestsInfo page #878

### DIFF
--- a/test-result-summary-client/src/Build/AllTestsInfo.jsx
+++ b/test-result-summary-client/src/Build/AllTestsInfo.jsx
@@ -164,7 +164,7 @@ const Build = () => {
             <TestBreadcrumb buildId={buildId} />
             <AlertMsg error={error} />
             <SearchOutput buildId={buildId} />
-            <TestTable title={'Tests'} testData={testData} parents={parents} />
+            <TestTable title={'Tests'} testData={testData} />
         </div>
     );
 };

--- a/test-result-summary-client/src/Build/AllTestsInfo.jsx
+++ b/test-result-summary-client/src/Build/AllTestsInfo.jsx
@@ -84,7 +84,10 @@ const Build = () => {
             return rt;
         });
 
-        setParents(fetchedParents);
+        // Filter out siblings builds (Build #77 - 74)
+        const filteredParents = fetchedParents.filter(parent => parent.buildNum > 77); 
+
+        setParents(filteredParents); // CHANGE: Setting filtered parents
         setTestData(fetchedTestData);
         setError(errorMsg);
     };

--- a/test-result-summary-client/src/Build/TestTable.jsx
+++ b/test-result-summary-client/src/Build/TestTable.jsx
@@ -271,8 +271,10 @@ export default class TestTable extends Component {
             },
         ];
         if (parents) {
+            //Filtering out siblings builds
+            const filteredParents = parents.filter(parent => parent.buildNum > 77); 
             columns.push(
-                ...parents.map((parent, i) => {
+                ...filteredParents.map((parent, i) => {
                     return {
                         title: (
                             <div>


### PR DESCRIPTION
Fix issue #880 

I had removed the sibling Build (build 77 -74) on allTestsInfo page
It looks like the below image

<img width="1170" alt="Screenshot 2024-06-09 at 5 07 32 PM" src="https://github.com/adoptium/aqa-test-tools/assets/143711987/08cffc1c-c85d-456f-9e93-ce8bcd7dafad">
