### PR TITLE
Set the minimum number of monitored builds to 10

### DIFF
--- a/TestResultSummaryService/BuildMonitor.js
+++ b/TestResultSummaryService/BuildMonitor.js
@@ -37,14 +37,14 @@ class BuildMonitor {
         // descending order
         allBuilds.sort((a, b) => parseInt(b.id) - parseInt(a.id));
         /*
-         * Loop through allBuilds or past 5 builds (whichever is
+         * Loop through allBuilds or past 10 builds (whichever is
          * less) to avoid OOM error. If there is not a match in db,
          * create the new build. Otherwise, break. Since allBuilds
          * are in descending order, we assume if we find a match,
          * all remaining builds that has a lower build number is in
          * db.
          */
-        const limit = Math.min(5, allBuilds.length);
+        const limit = Math.min(10, allBuilds.length);
         const testResults = new TestResultsDB();
         for (let i = 0; i < limit; i++) {
             const buildNum = parseInt(allBuilds[i].id, 10);


### PR DESCRIPTION
If a large number of builds (>5) are launched in a short period, TRSS only monitors the last 5 builds.
To avoid this, set the minimum number of monitored builds to 10.