### PR TITLE
Pull jdkVersion from parent if not in child name

### DIFF
--- a/test-result-summary-client/src/Build/Summary/ResultSummary.jsx
+++ b/test-result-summary-client/src/Build/Summary/ResultSummary.jsx
@@ -117,15 +117,16 @@ export default function ResultSummary() {
                         jdkImpl = 'j9';
                     }
                     // use non-capture group to ignore words evaluation and release if present
-                    const regex = /^jdk(\d*).?(?:-evaluation|-release)?-(\w+)-(\w+)-(\w+)/i;
+                    const regex =
+                        /^jdk(\d*).?(?:-evaluation|-release)?-(\w+)-(\w+)-(\w+)/i;
                     const tokens = buildName.match(regex);
                     if (Array.isArray(tokens) && tokens.length > 4) {
                         jdkVersion = tokens[1];
-                        const parentRegex = /openjdk(\d*)-pipeline/i;
+                        const parentRegex = /openjdk(\d+)-pipeline/i;
                         if (jdkVersion == '' && parentBuildInfo.buildName) {
-                            jdkVersion = parentBuildInfo.buildName.match(
-                                parentRegex
-                            ).tokens[1];
+                            jdkVersion =
+                                parentBuildInfo.buildName.match(parentRegex)
+                                    .tokens[1];
                         }
                         if (buildName.includes('alpine-linux')) {
                             platform = `${tokens[4]}_alpine-linux`;
@@ -144,7 +145,8 @@ export default function ResultSummary() {
                         }
                     }
                 } else if (buildName.startsWith('build')) {
-                    const regex = /Build_JDK(.+?)_(.+?_.+?(_xl|_fips)?)(_.+)?$/i;
+                    const regex =
+                        /Build_JDK(.+?)_(.+?_.+?(_xl|_fips)?)(_.+)?$/i;
                     const tokens = buildName.match(regex);
                     if (Array.isArray(tokens) && tokens.length > 3) {
                         jdkVersion = tokens[1];

--- a/test-result-summary-client/src/Build/Summary/ResultSummary.jsx
+++ b/test-result-summary-client/src/Build/Summary/ResultSummary.jsx
@@ -85,6 +85,13 @@ export default function ResultSummary() {
             const buildMap = {};
             let jdkVersionOpts = [];
             let jdkImplOpts = [];
+            let jdkVersion;
+            if (parentBuildInfo && parentBuildInfo.buildName) {
+                const parentRegex = /openjdk(\d+)-pipeline/i;
+                const parenttokens =
+                    parentBuildInfo.buildName.match(parentRegex);
+                jdkVersion = parenttokens[1];
+            }
 
             sdkBuilds.forEach((build) => {
                 const buildName = build.buildName.toLowerCase();
@@ -93,11 +100,7 @@ export default function ResultSummary() {
                 if (buildName.includes('_smoketests')) {
                     level = 'extended';
                 }
-                let jdkVersion, platform, jdkImpl;
-                const parentRegex = /openjdk(\d+)-pipeline/i;
-                const parenttokens =
-                    parentBuildInfo.buildName.match(parentRegex);
-                jdkVersion = parenttokens[1];
+                let platform, jdkImpl;
 
                 if (buildName.startsWith('jdk')) {
                     // SDK build and Smoke test platform format does not match with test build. Need to match the platform value.
@@ -124,8 +127,11 @@ export default function ResultSummary() {
                         /^jdk(\d*).?(?:-evaluation|-release)?-(\w+)-(\w+)-(\w+)/i;
                     const tokens = buildName.match(regex);
                     if (Array.isArray(tokens) && tokens.length > 4) {
-                        if (!jdkVersion && tokens[1]) {
+                        if (tokens[1]) {
                             jdkVersion = tokens[1];
+                        }
+                        if (!jdkVersion) {
+                            console.warn('jdkVersion is undefined');
                         }
                         if (buildName.includes('alpine-linux')) {
                             platform = `${tokens[4]}_alpine-linux`;

--- a/test-result-summary-client/src/Build/Summary/ResultSummary.jsx
+++ b/test-result-summary-client/src/Build/Summary/ResultSummary.jsx
@@ -117,11 +117,16 @@ export default function ResultSummary() {
                         jdkImpl = 'j9';
                     }
                     // use non-capture group to ignore words evaluation and release if present
-                    const regex =
-                        /^jdk(\d+).?(?:-evaluation|-release)?-(\w+)-(\w+)-(\w+)/i;
+                    const regex = /^jdk(\d*).?(?:-evaluation|-release)?-(\w+)-(\w+)-(\w+)/i;
                     const tokens = buildName.match(regex);
                     if (Array.isArray(tokens) && tokens.length > 4) {
                         jdkVersion = tokens[1];
+                        const parentRegex = /openjdk(\d*)-pipeline/i;
+                        if (jdkVersion == '' && parentBuildInfo.buildName) {
+                            jdkVersion = parentBuildInfo.buildName.match(
+                                parentRegex
+                            ).tokens[1];
+                        }
                         if (buildName.includes('alpine-linux')) {
                             platform = `${tokens[4]}_alpine-linux`;
                             if (buildName.includes('x64')) {
@@ -139,8 +144,7 @@ export default function ResultSummary() {
                         }
                     }
                 } else if (buildName.startsWith('build')) {
-                    const regex =
-                        /Build_JDK(.+?)_(.+?_.+?(_xl|_fips)?)(_.+)?$/i;
+                    const regex = /Build_JDK(.+?)_(.+?_.+?(_xl|_fips)?)(_.+)?$/i;
                     const tokens = buildName.match(regex);
                     if (Array.isArray(tokens) && tokens.length > 3) {
                         jdkVersion = tokens[1];

--- a/test-result-summary-client/src/Build/Summary/ResultSummary.jsx
+++ b/test-result-summary-client/src/Build/Summary/ResultSummary.jsx
@@ -56,7 +56,7 @@ export default function ResultSummary() {
             // get all SDK builds info
             const sdkBuildsRes = fetchData(
                 `/api/getAllChildBuilds${params({
-                    buildNameRegex: '^(jdk[0-9]{1,2}|Build_)',
+                    buildNameRegex: '^(jdk[0-9]{1,2}|jdk-|Build_)',
                     parentId,
                 })}`
             );
@@ -93,8 +93,11 @@ export default function ResultSummary() {
                 if (buildName.includes('_smoketests')) {
                     level = 'extended';
                 }
-
                 let jdkVersion, platform, jdkImpl;
+                const parentRegex = /openjdk(\d+)-pipeline/i;
+                const parenttokens =
+                    parentBuildInfo.buildName.match(parentRegex);
+                jdkVersion = parenttokens[1];
 
                 if (buildName.startsWith('jdk')) {
                     // SDK build and Smoke test platform format does not match with test build. Need to match the platform value.
@@ -121,12 +124,8 @@ export default function ResultSummary() {
                         /^jdk(\d*).?(?:-evaluation|-release)?-(\w+)-(\w+)-(\w+)/i;
                     const tokens = buildName.match(regex);
                     if (Array.isArray(tokens) && tokens.length > 4) {
-                        jdkVersion = tokens[1];
-                        const parentRegex = /openjdk(\d+)-pipeline/i;
-                        if (jdkVersion == '' && parentBuildInfo.buildName) {
-                            jdkVersion =
-                                parentBuildInfo.buildName.match(parentRegex)
-                                    .tokens[1];
+                        if (!jdkVersion && tokens[1]) {
+                            jdkVersion = tokens[1];
                         }
                         if (buildName.includes('alpine-linux')) {
                             platform = `${tokens[4]}_alpine-linux`;


### PR DESCRIPTION
Fixes #816 

Other wrapper scripts / parent jobs (such as AQA_Test_Pipeline) do not run builds, they only run test jobs which always have the version number in the child jobs, so this approach should cover our cases.  This will work for the standard naming used in ci-jenkins-pipelines top-level jobs.  