### PR TITLE
Avoid null error on some parent job types (e.g AQA_Test_Pipeline)

### DIFF
--- a/test-result-summary-client/src/Build/Summary/ResultSummary.jsx
+++ b/test-result-summary-client/src/Build/Summary/ResultSummary.jsx
@@ -90,7 +90,7 @@ export default function ResultSummary() {
                 const parentRegex = /openjdk(\d+)-pipeline/i;
                 const parenttokens =
                     parentBuildInfo.buildName.match(parentRegex);
-                jdkVersion = parenttokens[1];
+                jdkVersion = parenttokens?.[1] ?? null;
             }
 
             sdkBuilds.forEach((build) => {


### PR DESCRIPTION
This PR fixes null error when accessing parenttokens. The error occurs for certain types of parent jobs where the buildName does not match the expected pattern (e.g AQA_Test_Pipeline)