### PR TITLE
Remove buildType JCK from settings page

### DIFF
--- a/test-result-summary-client/src/Settings/Settings.jsx
+++ b/test-result-summary-client/src/Settings/Settings.jsx
@@ -238,11 +238,6 @@ export default class Settings extends Component {
                                             value: 'FVT',
                                         },
                                         {
-                                            key: 'JCK',
-                                            label: 'JCK',
-                                            value: 'JCK',
-                                        },
-                                        {
                                             key: 'Perf',
                                             label: 'Perf',
                                             value: 'Perf',


### PR DESCRIPTION
- Remove buildType JCK from from /admin/settings page

related: https://github.com/adoptium/aqa-test-tools/issues/973