### PR TITLE
Search adoptium/infrastructure and adoptium/aqa-build for Adoptium build only

### DIFF
--- a/test-result-summary-client/src/Build/PossibleIssues.jsx
+++ b/test-result-summary-client/src/Build/PossibleIssues.jsx
@@ -108,7 +108,7 @@ const PossibleIssues = () => {
         if (buildName.includes('j9') || buildName.includes('ibm')) {
             additionalRepo = '+repo:eclipse-openj9/openj9';
         }
-        else if (buildId.includes('hs')){
+        else if (buildName.includes('hs')){
             additionalRepo = '+repo:adoptium/infrastructure+repo:adoptium/aqa-build'
         }
         const response = await fetch(

--- a/test-result-summary-client/src/Build/PossibleIssues.jsx
+++ b/test-result-summary-client/src/Build/PossibleIssues.jsx
@@ -87,8 +87,8 @@ const PossibleIssues = () => {
         if (buildName.includes('j9') || buildName.includes('ibm')) {
             additionalRepo = '+repo:eclipse-openj9/openj9';
         }
-        else if (buildName.includes('hs')){
-            additionalRepo = '+repo:adoptium/infrastructure+repo:adoptium/aqa-build'
+        else if (buildName.includes('hs')) {
+            additionalRepo = '+repo:adoptium/infrastructure+repo:adoptium/aqa-build';
         }
         const response = await fetch(
             `https://api.github.com/search/issues?q=${generalTestName}+repo:adoptium/aqa-tests` +

--- a/test-result-summary-client/src/Build/PossibleIssues.jsx
+++ b/test-result-summary-client/src/Build/PossibleIssues.jsx
@@ -108,9 +108,12 @@ const PossibleIssues = () => {
         if (buildName.includes('j9') || buildName.includes('ibm')) {
             additionalRepo = '+repo:eclipse-openj9/openj9';
         }
+        else if (buildId.includes('hs')){
+            additionalRepo = '+repo:adoptium/infrastructure+repo:adoptium/aqa-build'
+        }
         const response = await fetch(
             `https://api.github.com/search/issues?q=${generalTestName}+repo:adoptium/aqa-tests` +
-                `+repo:adoptium/infrastructure+repo:adoptium/aqa-build+repo:adoptium/aqa-systemtest+repo:adoptium/TKG${additionalRepo}`,
+                `+repo:adoptium/aqa-systemtest+repo:adoptium/TKG${additionalRepo}`,
             {
                 method: 'get',
             }


### PR DESCRIPTION
Added logic to search for `+repo:adoptium/infrastructure+repo:adoptium/aqa-build` for Adoptium build only and not search these repo for openj9/ibm issues
Resolves: #962 
Signed-off-by :Denny Chacko Jacob <denny.cjacob@ibm.com>