### PR TITLE
Support benchmark data from multiple platforms

### DIFF
--- a/TestResultSummaryService/routes/getBenchmarkMetricProps.js
+++ b/TestResultSummaryService/routes/getBenchmarkMetricProps.js
@@ -5,10 +5,10 @@ module.exports = async (req, res) => {
     if (benchmarkName) {
         const key = utils.getBenchmarkParserKey(benchmarkName);
         if (key) {
-            res.json(benchmarkMetric[key]['metrics']);
+            return res.json(benchmarkMetric[key]['metrics']);
         }
     } else {
-        res.json(benchmarkMetric);
+        return res.json(benchmarkMetric);
     }
-    res.json();
+    return res.json();
 };


### PR DESCRIPTION
- group data based on benchmarkName, benchmarkVariant and metricsName
- fix `Cannot set headers after they are sent to the client` in getBenchmarkMetricProps.js

fixes: automation/issues/227