### PR TITLE
Added BugSpots workflow and shell script

### DIFF
--- a/.github/workflows/gw_comment_trigger.yml
+++ b/.github/workflows/gw_comment_trigger.yml
@@ -1,0 +1,260 @@
+name: Bugspots Analysis via Comment
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  parse-comment:
+    if: github.event.issue.pull_request == null && contains(github.event.comment.body, 'gw --repo')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      
+    outputs:
+      repo_url: ${{ steps.parse.outputs.repo_url }}
+      limit: ${{ steps.parse.outputs.limit }}
+      
+    steps:
+      - name: Parse comment
+        id: parse
+        run: |
+          comment_body="${{ github.event.comment.body }}"
+          echo "Comment body: $comment_body"
+          
+          # Extract repository URL
+          repo_url=$(echo "$comment_body" | grep -oP 'gw --repo \K[^\s]+' || echo "")
+          if [ -z "$repo_url" ]; then
+            echo "Error: No repository URL found in comment"
+            exit 1
+          fi
+          
+          # Extract limit with improved regex and validation
+          limit_raw=$(echo "$comment_body" | grep -oP -- '--limit\s+\K\d+' || echo "")
+          
+          # Validate and set limit (default to 10 if not specified or invalid)
+          if [ -n "$limit_raw" ] && [ "$limit_raw" -gt 0 ] && [ "$limit_raw" -le 100 ]; then
+            limit="$limit_raw"
+          else
+            limit="10"
+            if [ -n "$limit_raw" ]; then
+              echo "Warning: Invalid limit value '$limit_raw', using default 10"
+            fi
+          fi
+          
+          echo "repo_url=$repo_url" >> $GITHUB_OUTPUT
+          echo "limit=$limit" >> $GITHUB_OUTPUT
+          echo "Parsed repo: $repo_url, limit: $limit"
+
+  run-bugspots:
+    needs: parse-comment
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '2.7'
+          
+      - name: Install bugspots gem
+        run: gem install bugspots
+        
+      - name: Run Bugspots Comment Analyzer
+        id: bugspots
+        continue-on-error: true
+        run: |
+          chmod +x BugPredict/gw.sh
+          # Run the script and capture the exit code
+          ./BugPredict/gw.sh "${{ needs.parse-comment.outputs.repo_url }}" "${{ needs.parse-comment.outputs.limit }}"
+          
+      - name: Check for repository errors
+        id: check-errors
+        run: |
+          repo_name=$(basename "${{ needs.parse-comment.outputs.repo_url }}" .git)
+          
+          # Check if the bugspots step failed
+          if [ "${{ steps.bugspots.outcome }}" = "failure" ]; then
+            echo "analysis_failed=true" >> $GITHUB_OUTPUT
+            
+            # Check for specific error types
+            if [ -f "bugspots-results/bugspots-${repo_name}.err" ]; then
+              error_content=$(cat "bugspots-results/bugspots-${repo_name}.err")
+              if [[ "$error_content" == *"Clone failed"* ]]; then
+                echo "error_type=clone_failed" >> $GITHUB_OUTPUT
+              elif [[ "$error_content" == *"Invalid Git repository"* ]]; then
+                echo "error_type=invalid_repo" >> $GITHUB_OUTPUT
+              elif [[ "$error_content" == *"No commits found"* ]]; then
+                echo "error_type=no_commits" >> $GITHUB_OUTPUT
+              else
+                echo "error_type=unknown" >> $GITHUB_OUTPUT
+              fi
+            else
+              echo "error_type=unknown" >> $GITHUB_OUTPUT
+            fi
+          else
+            echo "analysis_failed=false" >> $GITHUB_OUTPUT
+          fi
+          
+      - name: Prepare error comment
+        if: steps.check-errors.outputs.analysis_failed == 'true'
+        run: |
+          repo_url="${{ needs.parse-comment.outputs.repo_url }}"
+          error_type="${{ steps.check-errors.outputs.error_type }}"
+          
+          echo "## ❌ Repository Analysis Failed" > comment.md
+          echo "" >> comment.md
+          echo "**Repository:** \`$repo_url\`" >> comment.md
+          echo "**Analysis Date:** $(date '+%Y-%m-%d %H:%M:%S UTC')" >> comment.md
+          echo "" >> comment.md
+          
+          case "$error_type" in
+            "clone_failed")
+              echo "### 🚫 Invalid Repository" >> comment.md
+              echo "" >> comment.md
+              echo "**Error:** Unable to clone the repository. This usually means:" >> comment.md
+              echo "- The repository URL is incorrect" >> comment.md
+              echo "- The repository does not exist" >> comment.md
+              echo "- The repository is private and not accessible" >> comment.md
+              echo "- The repository URL format is invalid" >> comment.md
+              ;;
+            "invalid_repo")
+              echo "### 🚫 Invalid Git Repository" >> comment.md
+              echo "" >> comment.md
+              echo "**Error:** The URL does not point to a valid Git repository." >> comment.md
+              echo "" >> comment.md
+              echo "Please ensure you're providing a valid GitHub repository URL." >> comment.md
+              ;;
+            "no_commits")
+              echo "### 📭 Empty Repository" >> comment.md
+              echo "" >> comment.md
+              echo "**Error:** The repository exists but has no commits." >> comment.md
+              echo "" >> comment.md
+              echo "Bugspots analysis requires commit history to analyze bug patterns." >> comment.md
+              ;;
+            *)
+              echo "### ⚠️ Analysis Error" >> comment.md
+              echo "" >> comment.md
+              echo "**Error:** An unexpected error occurred during analysis." >> comment.md
+              echo "" >> comment.md
+              repo_name=$(basename "$repo_url" .git)
+              if [ -f "bugspots-results/bugspots-${repo_name}.err" ]; then
+                echo "**Error details:**" >> comment.md
+                echo '```' >> comment.md
+                cat "bugspots-results/bugspots-${repo_name}.err" >> comment.md
+                echo '```' >> comment.md
+              fi
+              ;;
+          esac
+          
+          echo "" >> comment.md
+          echo "**Usage examples:**" >> comment.md
+          echo '```' >> comment.md
+          echo "gw --repo https://github.com/username/repository" >> comment.md
+          echo "gw --repo https://github.com/username/repository --limit 15" >> comment.md
+          echo '```' >> comment.md
+          
+      - name: Prepare success comment
+        if: steps.check-errors.outputs.analysis_failed == 'false'
+        run: |
+          repo_name=$(basename "${{ needs.parse-comment.outputs.repo_url }}" .git)
+          limit="${{ needs.parse-comment.outputs.limit }}"
+          
+          if [ -f "bugspots-results/bugspots-${repo_name}.log" ] && [ -s "bugspots-results/bugspots-${repo_name}.log" ]; then
+            # Parse the bugspots output to extract hotspots
+            if grep -q "Hotspots:" "bugspots-results/bugspots-${repo_name}.log"; then
+              echo "## 🎯 Bugspots Analysis Results" > comment.md
+              echo "" >> comment.md
+              echo "**Repository:** \`${{ needs.parse-comment.outputs.repo_url }}\`" >> comment.md
+              echo "**Analysis Date:** $(date '+%Y-%m-%d %H:%M:%S UTC')" >> comment.md
+              echo "" >> comment.md
+              
+              # Extract number of bugfix commits and hotspots from the summary
+              bugfix_commits=$(grep -oP 'Found \K\d+(?= bugfix commits)' "bugspots-results/bugspots-${repo_name}.log" || echo "unknown")
+              total_hotspots=$(grep -oP 'with \K\d+(?= hotspots)' "bugspots-results/bugspots-${repo_name}.log" || echo "unknown")
+              
+              echo "**Analysis Summary:**" >> comment.md
+              echo "- Found **${bugfix_commits}** bugfix commits" >> comment.md
+              echo "- Identified **${total_hotspots}** total hotspots" >> comment.md
+              echo "- Showing top **${limit}** files most likely to contain bugs" >> comment.md
+              echo "" >> comment.md
+              
+              # Extract hotspots section and get top N entries
+              echo "### 🔥 Top ${limit} Hotspots" >> comment.md
+              echo "" >> comment.md
+              echo '```' >> comment.md
+              echo "Score    File" >> comment.md
+              echo "-------  ----" >> comment.md
+              
+              # Use the pre-processed top N file created by gw.sh
+              if [ -f "bugspots-results/bugspots-${repo_name}-top.log" ]; then
+                cat "bugspots-results/bugspots-${repo_name}-top.log" >> comment.md
+              else
+                # Fallback to manual extraction
+                sed -n '/Hotspots:/,/^$/p' "bugspots-results/bugspots-${repo_name}.log" | \
+                grep -E '^\s*[0-9]+\.[0-9]+.*' | \
+                head -n "$limit" | \
+                sed 's/^\s*//' >> comment.md
+              fi
+              
+              echo '```' >> comment.md
+              echo "" >> comment.md
+              echo "> 💡 **How to read this:** Higher scores indicate files more likely to contain bugs." >> comment.md
+              echo "> Scores are based on frequency and recency of bug-fix commits affecting each file." >> comment.md
+              echo "" >> comment.md
+            else
+              # No hotspots section found
+              echo "## ⚠️ Bugspots Analysis Results" > comment.md
+              echo "" >> comment.md
+              echo "**Repository:** \`${{ needs.parse-comment.outputs.repo_url }}\`" >> comment.md
+              echo "**Analysis Date:** $(date '+%Y-%m-%d %H:%M:%S UTC')" >> comment.md
+              echo "" >> comment.md
+              echo "### 📭 No Hotspots Found" >> comment.md
+              echo "" >> comment.md
+              echo "The analysis completed but no hotspots were identified." >> comment.md
+              echo "" >> comment.md
+              echo "**Possible reasons:**" >> comment.md
+              echo "- Repository has very few or no bug-fix commits" >> comment.md
+              echo "- Commit messages don't match standard bug-fix patterns" >> comment.md
+              echo "- Repository is well-maintained with minimal bugs" >> comment.md
+              echo "" >> comment.md
+              echo "**Raw output preview:**" >> comment.md
+              echo '```' >> comment.md
+              head -n 20 "bugspots-results/bugspots-${repo_name}.log" >> comment.md
+              echo '```' >> comment.md
+            fi
+          else
+            echo "## ⚠️ Bugspots Analysis Results" > comment.md
+            echo "" >> comment.md
+            echo "**Repository:** \`${{ needs.parse-comment.outputs.repo_url }}\`" >> comment.md
+            echo "**Analysis Date:** $(date '+%Y-%m-%d %H:%M:%S UTC')" >> comment.md
+            echo "" >> comment.md
+            echo "### 📭 No Results Found" >> comment.md
+            echo "" >> comment.md
+            echo "No analysis results were generated." >> comment.md
+            echo "" >> comment.md
+            echo "**This could mean:**" >> comment.md
+            echo "- The repository has no commit history" >> comment.md
+            echo "- The repository could not be accessed" >> comment.md
+            echo "- The bugspots analysis encountered an unexpected issue" >> comment.md
+          fi
+          
+      - name: Comment on issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const comment = fs.readFileSync('comment.md', 'utf8');
+            
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: comment
+            });

--- a/BugPredict/gw.sh
+++ b/BugPredict/gw.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+
+set -e
+
+# Parse command line arguments
+REPO_URL="$1"
+LIMIT="${2:-10}"
+
+if [ -z "$REPO_URL" ]; then
+  echo "Usage: $0 <repository_url> [limit]"
+  echo "Example: $0 https://github.com/user/repo.git 15"
+  exit 1
+fi
+
+WORKDIR="bugspots-work-$(date +%s)"
+OUTPUT_DIR="bugspots-results"
+
+# Log current date and time for debugging
+echo "🚀 Bugspots Comment Analyzer starting at $(date '+%Y-%m-%d %H:%M:%S %Z')"
+echo "Repository: $REPO_URL"
+echo "File limit: $LIMIT"
+
+# Check if bugspots is installed
+if ! gem list bugspots -i > /dev/null; then
+  echo "Installing bugspots gem..."
+  gem install bugspots
+fi
+
+# Create output directory
+mkdir -p "$OUTPUT_DIR"
+
+echo "🔄 Cloning $REPO_URL ..."
+repo_name=$(basename "$REPO_URL" .git)
+
+# Try different branch names in order of preference
+branches=("main" "master" "develop" "dev")
+clone_success=false
+
+for branch in "${branches[@]}"; do
+  echo "Trying to clone branch: $branch"
+  if git clone --branch "$branch" --depth 1000 "$REPO_URL" "$WORKDIR/$repo_name" 2>/dev/null; then
+    clone_success=true
+    echo "✅ Successfully cloned branch: $branch"
+    break
+  fi
+done
+
+# If named branches fail, try default clone
+if [ "$clone_success" = false ]; then
+  echo "Named branches failed, trying default clone..."
+  if git clone --depth 1000 "$REPO_URL" "$WORKDIR/$repo_name"; then
+    clone_success=true
+    echo "✅ Successfully cloned with default branch"
+  fi
+fi
+
+if [ "$clone_success" = false ]; then
+  echo "❌ Error: Failed to clone $REPO_URL" >&2
+  echo "Clone failed for $repo_name at $(date '+%Y-%m-%d %H:%M:%S %Z')" > "$OUTPUT_DIR/bugspots-${repo_name}.err"
+  exit 1
+fi
+
+# Verify repository
+if [ ! -d "$WORKDIR/$repo_name/.git" ]; then
+  echo "❌ Error: $repo_name is not a valid Git repository" >&2
+  echo "Invalid Git repository: $repo_name at $(date '+%Y-%m-%d %H:%M:%S %Z')" > "$OUTPUT_DIR/bugspots-${repo_name}.err"
+  exit 1
+fi
+
+echo "📊 Running Bugspots analysis for $repo_name ..."
+cd "$WORKDIR/$repo_name"
+
+# Check if repository has any commits
+if ! git log --oneline -1 > /dev/null 2>&1; then
+  echo "❌ Error: Repository has no commits" >&2
+  echo "No commits found in repository at $(date '+%Y-%m-%d %H:%M:%S %Z')" > "../../$OUTPUT_DIR/bugspots-${repo_name}.err"
+  cd - > /dev/null
+  rm -rf "$WORKDIR"
+  exit 1
+fi
+
+# Count total commits for context
+total_commits=$(git rev-list --count HEAD 2>/dev/null || echo "unknown")
+echo "📈 Repository has $total_commits commits in current branch"
+
+# Run bugspots with simplified word pattern
+echo "📊 Running Bugspots for $repo_name ..."
+echo "Executing: git bugspots -w fix" >&2
+if ! git bugspots -w fix > "../../$OUTPUT_DIR/bugspots-${repo_name}.log" 2> "../../$OUTPUT_DIR/bugspots-${repo_name}.err"; then
+  echo "❌ Error: Bugspots failed for $repo_name. Check $OUTPUT_DIR/bugspots-${repo_name}.err" >&2
+  if [ -s "../../$OUTPUT_DIR/bugspots-${repo_name}.err" ]; then
+    echo "Error details:"
+    cat "../../$OUTPUT_DIR/bugspots-${repo_name}.err" >&2
+  fi
+  cd - > /dev/null
+  rm -rf "$WORKDIR"
+  exit 1
+else
+  echo "✅ Bugspots analysis successful for $repo_name"
+  echo "Results saved to $OUTPUT_DIR/bugspots-${repo_name}.log"
+  
+  # Check if we have results and if hotspots section exists
+  if [ -s "../../$OUTPUT_DIR/bugspots-${repo_name}.log" ]; then
+    if grep -q "Hotspots:" "../../$OUTPUT_DIR/bugspots-${repo_name}.log"; then
+      # Extract and count hotspots
+      hotspot_lines=$(sed -n '/Hotspots:/,$p' "../../$OUTPUT_DIR/bugspots-${repo_name}.log" | tail -n +2 | grep -E '^\s*[0-9]+\.[0-9]+.*' | wc -l)
+      echo "📋 Found $hotspot_lines hotspot files"
+      
+      # Extract top N hotspots after "Hotspots:" line
+      echo ""
+      echo "🎯 Top $LIMIT hotspots found:"
+      echo "================================"
+      sed -n '/Hotspots:/,$p' "../../$OUTPUT_DIR/bugspots-${repo_name}.log" | \
+      tail -n +2 | \
+      grep -E '^\s*[0-9]+\.[0-9]+.*' | \
+      head -n "$LIMIT" | \
+      sed 's/^\s*//'
+      echo "================================"
+      
+      # Create a clean output file with only the top N hotspots for the GitHub Actions
+      sed -n '/Hotspots:/,$p' "../../$OUTPUT_DIR/bugspots-${repo_name}.log" | \
+      tail -n +2 | \
+      grep -E '^\s*[0-9]+\.[0-9]+.*' | \
+      head -n "$LIMIT" | \
+      sed 's/^\s*//' > "../../$OUTPUT_DIR/bugspots-${repo_name}-top.log"
+      
+    else
+      echo "⚠️  Analysis completed but no hotspots section found" >&2
+      echo "No hotspots section found in output at $(date '+%Y-%m-%d %H:%M:%S %Z')" > "../../$OUTPUT_DIR/bugspots-${repo_name}.err"
+    fi
+  else
+    echo "⚠️  No files found matching bug fix patterns" >&2
+    echo "No bug patterns found in commit messages at $(date '+%Y-%m-%d %H:%M:%S %Z')" > "../../$OUTPUT_DIR/bugspots-${repo_name}.err"
+  fi
+fi
+
+cd - > /dev/null
+
+# Clean up temporary directories
+rm -rf "$WORKDIR"
+
+echo "🏁 Bugspots Comment Analyzer completed at $(date '+%Y-%m-%d %H:%M:%S %Z')"


### PR DESCRIPTION
These scripts should allow contributors to perform Static Analysis on any input repository and get the top 10 (or any user-specified number) hotspots that are most likely to contain bugs.

Comment Format:
```
gw --repo <repo_link>
```
```
gw --repo <repo_link> --limit <number_of_files>
```

Signed-off-by: Anirudh Sengar anirudhsengar3@gmail.com