### PR TITLE
Enabled Dacapo on Dashboard

### DIFF
--- a/test-result-summary-client/src/Dashboard/Widgets/Graph/Dacapo.jsx
+++ b/test-result-summary-client/src/Dashboard/Widgets/Graph/Dacapo.jsx
@@ -65,7 +65,8 @@ export default class Dacapo extends Component {
 
         // combine results having the same JDK build date
         results.forEach((t, i) => {
-            let jdkDate = t.jdkDate || (t.timestamp ? new Date(t.timestamp).toISOString().slice(0,10) : null);
+            //t.jdkDate is currently not in use
+            let jdkDate = (t.timestamp ? new Date(t.timestamp).toISOString().slice(0,10) : null);
             if (t.buildResult !== 'SUCCESS' || !jdkDate) return;
             jdkDate = ' ' + jdkDate.replaceAll('-', '');
             resultsByJDKBuild[jdkDate] = resultsByJDKBuild[jdkDate] || [];


### PR DESCRIPTION
Dacapo.jsx matches new datastructure:
1. Since jdkDate is null, derive it from t.timestamp.
2. Extract metric with respect to test.duration and test.benchmarkName instead of tests.testData.metrics

Notes for possible related issues:
-Can optimize the code, currently I believe there are wasteful null values in resultsByJDKBuild due to change 2. 
-Current code assumes only one iteration per benchmark, but there could be multiple iterations.

Fixes: #1049

TRSS local result: 
![image](https://github.com/user-attachments/assets/cdd62e71-2ef3-441b-a93a-6d68d253cdfe)
