### PR TITLE
Enable Build Tree for Perf Pipeline 

### DIFF
--- a/test-result-summary-client/src/Build/TopLevelBuildTable.jsx
+++ b/test-result-summary-client/src/Build/TopLevelBuildTable.jsx
@@ -167,26 +167,15 @@ function TopLevelBuildTable(props) {
                         );
                     }
                 } else {
-                    // Return a link to the build detail page
+                    // Return a JSX element with a 'BuildStatus' and 'renderPublishName' component, passing in relevant props.
                     return (
                         <div>
-                            <Link
-                                to={{
-                                    pathname: '/buildDetail',
-                                    search: params({ parentId: value._id }),
-                                }}
-                                style={{
-                                    color:
-                                        result === 'SUCCESS'
-                                            ? '#2cbe4e'
-                                            : result === 'FAILURE'
-                                            ? '#f50'
-                                            : '#DAA520',
-                                }}
-                            >
-                                {' '}
-                                Build #{value.buildNum}
-                            </Link>
+                                <BuildStatus 
+                                        status={value.buildResult}
+                                        id={value._id}
+                                        buildNum={value.buildNum}
+                                />
+                                {renderPublishName(value)}
                         </div>
                     );
                 }


### PR DESCRIPTION
Replaced link to /buildDetail with BuildStatus
inside renderBuild when value.tests is null.

Redo of PR #1057, hard reset with upstream before branching to get rid of weird package directory changes. 

TRSS local results: 
![image](https://github.com/user-attachments/assets/ad0b22ea-cef7-41a0-8c89-883f5c5b4cef)

Fixes: #1048