### PR TITLE
Fix build name column in Traffic Light table

### DIFF
--- a/test-result-summary-client/src/TrafficLight/TrafficLight.jsx
+++ b/test-result-summary-client/src/TrafficLight/TrafficLight.jsx
@@ -248,11 +248,17 @@ function TrafficLight() {
             );
         }
     };
-    const firstRow = first(tableData) ?? {};
-    const groups = Object.values(firstRow) ?? [];
+
     const buildNameTitles = uniq(
-        groups.map(({ buildNameTitle }) => buildNameTitle).filter(identity)
+        tableData
+            .map((row = {}) =>
+                Object.values(row)
+                    .map(({ buildNameTitle }) => buildNameTitle)
+                    .filter(identity)
+            )
+            .flat()
     );
+
     const columns = [
         {
             title: 'Benchmark Name',


### PR DESCRIPTION
The table renders correctly when benchmarks are executed across all platforms. However, if benchmarks are only run on a subset of platforms, the Build Name column does not display all entries. This PR addresses the issue by checking for unique buildNameTitle values across all benchmarks.

Fixes: automation/issues/560