### PR TITLE
Display N/A and Hang suspected in Duration column

### DIFF
--- a/test-result-summary-client/src/Build/AllTestsInfo.jsx
+++ b/test-result-summary-client/src/Build/AllTestsInfo.jsx
@@ -105,11 +105,19 @@ const Build = () => {
         let testResult = [];
         if (builds[0].tests !== undefined) {
             testResult = builds[0].tests.map((test) => {
+                let duration = test.duration;
+                if (!duration) {
+                    if (!test.startTime) {
+                        duration = null;
+                    } else {
+                        duration = Infinity;
+                    }
+                }
                 const ret = {
                     key: test._id,
                     sortName: test.testName,
                     testName: test.testName,
-                    duration: test.duration,
+                    duration,
                     machine: builds[0].machine,
                     sortMachine: builds[0].machine,
                     buildName: buildData[0].buildName,

--- a/test-result-summary-client/src/Build/Duration.jsx
+++ b/test-result-summary-client/src/Build/Duration.jsx
@@ -1,6 +1,8 @@
 export default function renderDuration(ms) {
     if (ms === null) {
         return 'N/A';
+    } else if (ms === Infinity) {
+        return 'Hang suspected';
     }
     const milliseconds = parseInt(ms % 1000, 10);
     const seconds = parseInt((ms / 1000) % 60, 10);


### PR DESCRIPTION
Improve TRSS duration display:

- N/A -> no `Start Time`
- Hang suspected -> has `Start Time`, but no `Finish Time`

related: runtimes/backlog/issues/1692