### PR TITLE
WIP: Strip out 8mha values when parsing startby string

### DIFF
--- a/TestResultSummaryService/parsers/Parser.js
+++ b/TestResultSummaryService/parsers/Parser.js
@@ -162,7 +162,7 @@ class Parser {
         const userRegex = /Started by ?(.*?)[\r\n]+/;
         if ((m = userRegex.exec(output)) !== null) {
             if (output.includes("8mha")) {
-                user = m[1].replaceAll(/\u001b\[8mha.*?\[0m/g, "");
+                user = m[1].replaceAll(/\u001b/g, "").replaceAll(/\[8mha.*?\[0m/g, "");
             } else {
                 user = m[1];
             }

--- a/TestResultSummaryService/parsers/Parser.js
+++ b/TestResultSummaryService/parsers/Parser.js
@@ -161,7 +161,11 @@ class Parser {
         let user = null;
         const userRegex = /Started by ?(.*?)[\r\n]+/;
         if ((m = userRegex.exec(output)) !== null) {
-            user = m[1];
+            if (output.includes("8mha")) {
+                user = m[1].replaceAll(/\u001b\[8mha.*?\[0m/g, "");
+            } else {
+                user = m[1];
+            }
         }
         return user;
     }


### PR DESCRIPTION
Because otherwise you get this: https://github.com/adoptium/aqa-test-tools/issues/1084

Deliberately omitting a github "resolves" keyword because this is a concept PR.