### PR TITLE
Add DB query checks to prevent crash if no data returned

### DIFF
--- a/TestResultSummaryService/routes/getHistoryPerTest.js
+++ b/TestResultSummaryService/routes/getHistoryPerTest.js
@@ -41,8 +41,11 @@ module.exports = async (req, res) => {
             { _id: element.parentId },
             { buildNum: 1 }
         );
-        element.parentNum = parentObj[0].buildNum;
-        result.push(element);
+        // Check we found a parentObj in case history has been purged
+        if (parentObj && parentObj.length > 0) {
+            element.parentNum = parentObj[0].buildNum;
+            result.push(element);
+        }
     }
 
     res.send(result);

--- a/TestResultSummaryService/routes/getTestById.js
+++ b/TestResultSummaryService/routes/getTestById.js
@@ -3,9 +3,12 @@ module.exports = async (req, res) => {
     const { id } = req.query;
     const testResultsDB = new TestResultsDB();
     const data = await testResultsDB.getTestById(id);
-    res.send({
-        buildId: data[0]._id,
-        artifactory: data[0].artifactory,
-        ...data[0].tests,
-    });
+    // Check we got data in case DB was purged
+    if (data && data.length > 0) {
+        res.send({
+            buildId: data[0]._id,
+            artifactory: data[0].artifactory,
+            ...data[0].tests,
+        });
+    }
 };


### PR DESCRIPTION
Add safety checks to prevent the following errors in case DB entries don't exist for any reason:
```
TypeError: Cannot read properties of undefined (reading '_id')
    at module.exports (/usr/src/app/routes/getTestById.js:7:26)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
TypeError: Cannot read properties of undefined (reading 'buildNum')
    at module.exports (/usr/src/app/routes/getHistoryPerTest.js:44:42)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```