### PR TITLE
Add support for user-configurable Git hosts & repo lists for internal/external issue search #1110

### DIFF
--- a/TestResultSummaryService/config/possibleIssueRepos.json
+++ b/TestResultSummaryService/config/possibleIssueRepos.json
@@ -1,0 +1,19 @@
+[
+  {
+    "apiBase": "https://api.github.ibm.com",
+    "repos": [
+      "repo:runtimes/backlog",
+      "repo:runtimes/infrastructure"
+    ],
+    "tokenKey": "https://api.github.ibm.com",
+    "maxResults": 50
+  },
+  {
+    "apiBase": "https://api.github.com",
+    "repos": [
+      "repo:eclipse-openj9/openj9"
+    ],
+    "tokenKey": "https://api.github.com",
+    "maxResults": 50
+  }
+]

--- a/TestResultSummaryService/routes/getInternalGitIssues.js
+++ b/TestResultSummaryService/routes/getInternalGitIssues.js
@@ -2,45 +2,91 @@ const got = require('got');
 const ArgParser = require('../ArgParser');
 
 /**
- * getInternalGitIssues seraches text in the repos and return matched git issues
- * api/getInternalGitIssues?text=jdk_util
- * @param {string} text Required. Search text string. i.e., jdk_math
- * @return {object} matched git issues
+ * getInternalGitIssues searches text across user-configured Git hosts and repos.
+ *
+ * This endpoint supports multiple GitHub-style hosts (e.g., github.ibm.com, github.com)
+ * as defined in the user-provided trssConf.json file loaded via --configFile.
+ *
+ * Example:
+ *   GET api/getInternalGitIssues?text=jdk_util
+ *
+ * Config format (per host):
+ * {
+ *   "github.ibm.com": {
+ *     "token": "<optional_token>",
+ *     "repos": ["owner1/repo1", "owner2/repo2"]
+ *   },
+ *   "github.com": {
+ *     "token": "<optional_token>",
+ *     "repos": ["adoptium/aqa-test-tools"]
+ *   }
+ * }
+ *
+ * Behavior:
+ *   - Loops through each host defined in config
+ *   - Builds GitHub search queries for each repo in that host
+ *   - Calls the host's /search/issues endpoint using got()
+ *   - Collects and merges issue results from all hosts
+ *   - Returns a combined array of GitHub issue objects
+ *
+ * @param {string} text - Required search query string
+ * @return {Array<object>} Combined list of matched issues from all configured hosts
  */
 
 module.exports = async (req, res) => {
     try {
         const { text } = req.query;
-        if (text) {
-            const url = 'https://api.github.ibm.com';
-            const repos = 'repo:runtimes/backlog+repo:runtimes/infrastructure';
-            const credentails = ArgParser.getConfig();
-            if (credentails[url] && credentails[url].token) {
-                const response = await got(
-                    `${url}/search/issues?q=${text}+${repos}`,
-                    {
-                        method: 'get',
-                        headers: {
-                            Authorization: `Bearer ${credentails[url].token}`,
-                            Accept: 'application/vnd.github+json',
-                        },
-                        responseType: 'json',
-                    }
-                );
-                if (response && response.body) {
-                    res.send(response.body.items);
-                } else {
-                    res.send([]);
-                }
-            } else {
-                res.send(`${url} and/or token not appear in trssConf.json`);
+        if (!text) return res.send('expect text query parameter');
+
+        const config = ArgParser.getConfig();
+        if (!config)
+            return res.send('No config file loaded. Use --configFile=<path>');
+
+        const allIssues = [];
+
+        // Loop through each host in the config
+        for (const host of Object.keys(config)) {
+            const hostCfg = config[host];
+
+            // Validate host entry
+            if (!hostCfg || !hostCfg.repos || !Array.isArray(hostCfg.repos)) {
+                console.warn(`Skipping host ${host}: repos[] missing`);
+                continue;
             }
-        } else {
-            res.send('expect text query parameter');
+
+            const repoQuery = hostCfg.repos.map((r) => `repo:${r}`).join('+');
+
+            const baseUrl = host.startsWith('http') ? host : `https://${host}`;
+
+            const url = `${baseUrl}/search/issues?q=${text}+${repoQuery}`;
+
+            try {
+                const response = await got(url, {
+                    method: 'get',
+                    headers: {
+                        ...(hostCfg.token
+                            ? { Authorization: `Bearer ${hostCfg.token}` }
+                            : {}),
+                        Accept: 'application/vnd.github+json',
+                    },
+                    responseType: 'json',
+                });
+
+                if (response.body?.items) {
+                    allIssues.push(...response.body.items);
+                }
+            } catch (innerErr) {
+                console.error(
+                    `Error fetching from host ${host}:`,
+                    innerErr.message
+                );
+            }
         }
+
+        return res.send(allIssues);
     } catch (error) {
         const rawError = error.response?.data || error.message;
         console.error('Error fetching repos:', rawError);
-        res.status(500).json({ error: String(rawError) });
+        return res.status(500).json({ error: String(rawError) });
     }
 };


### PR DESCRIPTION
This PR enhances the `getInternalGitIssues` API to support user configurable GitHub style hosts and dynamic repository lists defined in a config file (`trssConf.json`).
This allows TRSS to search issues across multiple Git providers, including GitHub Enterprise instances (e.g., github.ibm.com) and public GitHub, without requiring code changes.

The frontend (`PossibleIssues.jsx`) was updated accordingly to consume the new API.

### Motivation
Previously, TRSS only supported a hard coded GitHub Enterprise search.
The request in issue #1109 asked for:
- User configurable repo sources
- Future support for multiple vendors
- A dedicated config file to store repos and tokens

This PR implements that. 


