### PR TITLE
Add TRSS frontend express server on error logging

### DIFF
--- a/TestResultSummaryService/frontend.js
+++ b/TestResultSummaryService/frontend.js
@@ -51,6 +51,11 @@ expressSwagger(options);
 // all environments
 app.set('port', process.env.PORT || 3001);
 
-app.listen(app.get('port'), function () {
+const server = app.listen(app.get('port'), function () {
     logger.info('Express server listening on port ' + app.get('port'));
 });
+
+server.on('error', (err) => {
+  logger.error('Express server error: ' +  err.message);
+});
+


### PR DESCRIPTION
Add TRSS frontend express server on error logging so we might see error information from the frontend Express seerver.

Related to https://github.com/adoptium/aqa-test-tools/issues/1146

Unsure if this will catch "async" errors/exceptions, which are more likely to crash the Express server/Node process?
