### PR TITLE
Update the ResultSummary Grid view to include remote Jenkins job status

### DIFF
--- a/TestResultSummaryService/routes/getRemoteJckBuildInfo.js
+++ b/TestResultSummaryService/routes/getRemoteJckBuildInfo.js
@@ -1,0 +1,108 @@
+// Assisted by IBM Bob
+
+const LogStream = require('../LogStream');
+
+/**
+ * GET /getJckBuildInfo?url=<jenkinsBaseUrl>&buildName=AQA_Test_Pipeline_JCK&buildNum=<n>
+ *
+ * Parses the console log of an AQA_Test_Pipeline_JCK build to extract the
+ * status of each remotely-triggered JCK test job.
+ *
+ * Returns an array of objects:
+ *   [{ target, platform, jdkVersion, displayName, remoteUrl, buildResult }, ...]
+ *
+ * Parsing is based on two console patterns:
+ *   "Triggering <target>.jck on <platform> with JDK <version>"
+ *   "Remote build URL: <url>"
+ *   "Remote job <displayName> Status: <result>"
+ */
+module.exports = async (req, res) => {
+    const { url, buildName, buildNum } = req.query;
+    if (!url || !buildName || !buildNum) {
+        return res.send({
+            error: 'url, buildName and buildNum are required',
+        });
+    }
+
+    try {
+        const logStream = new LogStream({
+            baseUrl: url,
+            job: buildName,
+            build: parseInt(buildNum, 10),
+        });
+        const output = await logStream.next(0);
+
+        const jobs = parseJckConsole(output);
+        res.send(jobs);
+    } catch (e) {
+        res.send({ error: e.toString() });
+    }
+};
+
+/**
+ * Parse the raw console text and return an array of JCK remote job descriptors.
+ *
+ * The console interleaves trigger blocks with polling lines so we collect
+ * trigger metadata (target / platform / jdkVersion) in order, then pair each
+ * "Remote build URL" and "Remote job … Status" line with the corresponding
+ * trigger entry by index.
+ */
+function parseJckConsole(text) {
+    const lines = text.split('\n');
+
+    // ---- pass 1: collect trigger records in order --------------------------
+    // Each "Triggering <target>.jck on <platform> with JDK <version>" marks the
+    // start of a new remote trigger block.
+    const triggerRe =
+        /Triggering\s+(\S+\.jck)\s+on\s+(\S+)\s+with\s+JDK\s+(\S+)/i;
+    const remoteUrlRe = /Remote build URL:\s*(https?:\/\/\S+)/i;
+    const statusRe =
+        /Remote job\s+(.+?)\s+Status:\s*(SUCCESS|UNSTABLE|FAILURE|ABORTED)/i;
+
+    const triggers = []; // { target, platform, jdkVersion }
+    const remoteUrls = []; // collected in order
+    const statusEntries = []; // { displayName, buildResult }
+
+    for (const line of lines) {
+        const stripped = line.replace(/^\d{2}:\d{2}:\d{2}\s+/, '').trim();
+
+        const trigMatch = stripped.match(triggerRe);
+        if (trigMatch) {
+            triggers.push({
+                target: trigMatch[1].replace(/\.jck$/i, ''), // e.g. "sanity"
+                platform: trigMatch[2],
+                jdkVersion: trigMatch[3],
+                remoteUrl: null,
+                buildResult: null,
+                displayName: null,
+            });
+            continue;
+        }
+
+        const urlMatch = stripped.match(remoteUrlRe);
+        if (urlMatch) {
+            remoteUrls.push(urlMatch[1]);
+            continue;
+        }
+
+        const statusMatch = stripped.match(statusRe);
+        if (statusMatch) {
+            statusEntries.push({
+                displayName: statusMatch[1].trim(),
+                buildResult: statusMatch[2],
+            });
+        }
+    }
+
+    // ---- pass 2: pair urls and statuses with triggers by index -------------
+    // Remote URLs and status entries appear in the same order as triggers.
+    for (let i = 0; i < triggers.length; i++) {
+        if (i < remoteUrls.length) triggers[i].remoteUrl = remoteUrls[i];
+        if (i < statusEntries.length) {
+            triggers[i].buildResult = statusEntries[i].buildResult;
+            triggers[i].displayName = statusEntries[i].displayName;
+        }
+    }
+
+    return triggers;
+}

--- a/TestResultSummaryService/routes/index.js
+++ b/TestResultSummaryService/routes/index.js
@@ -11,6 +11,7 @@ app.get(
 app.get('/deleteCollection', require('./deleteCollection'));
 app.get('/deleteUnusedOutput', require('./deleteUnusedOutput'));
 app.get('/getAllChildBuilds', require('./getAllChildBuilds'));
+app.get('/getRemoteJckBuildInfo', require('./getRemoteJckBuildInfo'));
 app.get('/getAllTestsWithHistory', require('./getAllTestsWithHistory'));
 app.get('/getApplicationTests', require('./getApplicationTests'));
 app.get('/getAuditLogs', require('./getAuditLogs'));

--- a/test-result-summary-client/src/Build/Summary/Overview.jsx
+++ b/test-result-summary-client/src/Build/Summary/Overview.jsx
@@ -115,7 +115,7 @@ export default class Overview extends Component {
                                 <Divider>Test Summary</Divider>
                             </Col>
                             <Col span={6}>
-                                <Divider>Pass Percentage</Divider>
+                                <Divider>Pass Percentage (excl. Remote JCK)</Divider>
                             </Col>
                             <Col span={6}>
                                 <Divider>Build Result</Divider>
@@ -177,7 +177,7 @@ export default class Overview extends Component {
                             </Col>
                             <Col span={6}>
                                 <div>
-                                    <Tooltip title="Pass % = (Passed/Executed) * 100">
+                                    <Tooltip title="Pass % = (Passed/Executed) * 100. Excludes Remote JCK targets.">
                                         <span style={{ fontSize: '38px' }}>
                                             {passPercentage
                                                 ? passPercentage.toFixed(2) +

--- a/test-result-summary-client/src/Build/Summary/ResultGrid.jsx
+++ b/test-result-summary-client/src/Build/Summary/ResultGrid.jsx
@@ -54,6 +54,7 @@ class Cell extends Component {
                                 const result = groups[group].buildResult;
                                 const rerunBuildUrl =
                                     groups[group].rerunBuildUrl;
+                                const jckPublicUrl = groups[group].jckPublicUrl;
                                 let element = '';
                                 if (!groups[group].testSummary) {
                                     element = (
@@ -66,8 +67,20 @@ class Cell extends Component {
                                                 target="_blank"
                                                 rel="noopener noreferrer"
                                             >
-                                                Jenkins Link
+                                                {jckPublicUrl ? 'Jenkins Link (priv)' : 'Jenkins Link'}
                                             </a>
+                                            {jckPublicUrl && (
+                                                <>
+                                                    <br />
+                                                    <a
+                                                        href={jckPublicUrl}
+                                                        target="_blank"
+                                                        rel="noopener noreferrer"
+                                                    >
+                                                        Jenkins Link (pub)
+                                                    </a>
+                                                </>
+                                            )}
                                         </div>
                                     );
                                 } else {
@@ -114,8 +127,20 @@ class Cell extends Component {
                                                 target="_blank"
                                                 rel="noopener noreferrer"
                                             >
-                                                Test build
+                                                {jckPublicUrl ? 'Test build (priv)' : 'Test build'}
                                             </a>
+                                            {jckPublicUrl && (
+                                                <>
+                                                    <br />
+                                                    <a
+                                                        href={jckPublicUrl}
+                                                        target="_blank"
+                                                        rel="noopener noreferrer"
+                                                    >
+                                                        Jenkins Link (pub)
+                                                    </a>
+                                                </>
+                                            )}
                                         </div>
                                     );
                                 }

--- a/test-result-summary-client/src/Build/Summary/ResultSummary.jsx
+++ b/test-result-summary-client/src/Build/Summary/ResultSummary.jsx
@@ -44,6 +44,66 @@ export default function ResultSummary() {
     });
 
     useEffect(() => {
+        const loadJckResults = async (jckBuilds) => {
+            // Collect all JCK entries first, then apply in a single setState using
+            // prevState.buildMap so we never overwrite concurrently-committed state.
+            const jckEntries = []; // [{ platform, jdkVersion, level, group, jdkImpl, entry }]
+            try {
+                await Promise.all(
+                    jckBuilds.map(async (jckBuild) => {
+                        if (!jckBuild.buildUrl || !jckBuild.buildNum) return;
+                        const baseUrl = jckBuild.buildUrl.replace(
+                            /\/job\/[^/]+\/\d+\/?$/,
+                            ''
+                        );
+                        const jckResults = await fetchData(
+                            `/api/getRemoteJckBuildInfo${params({
+                                url: baseUrl,
+                                buildName: jckBuild.buildName,
+                                buildNum: jckBuild.buildNum,
+                            })}`
+                        );
+                        if (!Array.isArray(jckResults)) return;
+                        jckResults.forEach(
+                            ({ target, platform, jdkVersion, buildResult, remoteUrl }) => {
+                                if (!target || !platform || !jdkVersion) return;
+                                jckEntries.push({
+                                    platform,
+                                    jdkVersion,
+                                    level: target, // sanity / extended / special / dev
+                                    group: 'jck',
+                                    jdkImpl: 'hs', // JCK compliance tests are Temurin (hotspot) only
+                                    entry: {
+                                        buildResult: buildResult || null,
+                                        buildUrl: remoteUrl || jckBuild.buildUrl,
+                                        jckPublicUrl: jckBuild.buildUrl,
+                                        buildId: jckBuild._id,
+                                        hasChildren: false,
+                                        testSummary: null,
+                                    },
+                                });
+                            }
+                        );
+                    })
+                );
+            } catch (e) {
+                console.error('Failed to fetch JCK build info:', e);
+            }
+            if (jckEntries.length === 0) return;
+            setState((prevState) => {
+                // Deep-copy only the affected paths so we don't mutate existing state
+                const buildMap = { ...prevState.buildMap };
+                jckEntries.forEach(({ platform, jdkVersion, jdkImpl, level, group, entry }) => {
+                    buildMap[platform] = { ...buildMap[platform] };
+                    buildMap[platform][jdkVersion] = { ...buildMap[platform][jdkVersion] };
+                    buildMap[platform][jdkVersion][jdkImpl] = { ...buildMap[platform][jdkVersion][jdkImpl] };
+                    buildMap[platform][jdkVersion][jdkImpl][level] = { ...buildMap[platform][jdkVersion][jdkImpl][level] };
+                    buildMap[platform][jdkVersion][jdkImpl][level][group] = entry;
+                });
+                return { ...prevState, buildMap };
+            });
+        };
+
         const updateData = async () => {
             const { parentId } = getParams(location.search);
 
@@ -73,12 +133,26 @@ export default function ResultSummary() {
                     parentId,
                 })}`
             );
-            const [summary, buildInfo, sdkBuilds, builds] = await Promise.all([
-                summaryRes,
-                buildInfoRes,
-                sdkBuildsRes,
-                buildsRes,
-            ]);
+
+            // get JCK pipeline child builds
+            const jckBuildsRes = fetchData(
+                `/api/getAllChildBuilds${params({
+                    buildNameRegex: '^AQA_Test_Pipeline_JCK$',
+                    parentId,
+                })}`
+            );
+
+            const [summary, buildInfo, sdkBuilds, builds, jckBuilds] =
+                await Promise.all([
+                    summaryRes,
+                    buildInfoRes,
+                    sdkBuildsRes,
+                    buildsRes,
+                    jckBuildsRes,
+                ]).catch((e) => {
+                    console.error('Promise.all failed:', e);
+                    return [undefined, undefined, [], [], []];
+                });
             const parentBuildInfo = buildInfo[0] || {};
             let childBuildsResult = 'UNDEFINED';
             let javaVersion = null;
@@ -192,6 +266,7 @@ export default function ResultSummary() {
 
                 childBuildsResult = setBuildsStatus(build, childBuildsResult);
             });
+
             builds.sort((a, b) => a.buildName.localeCompare(b.buildName));
 
             builds.forEach((build) => {
@@ -321,6 +396,9 @@ export default function ResultSummary() {
             jdkVersionOpts = [...new Set(jdkVersionOpts)].sort(order);
             jdkImplOpts = [...new Set(jdkImplOpts)].sort(order);
 
+            // Render the grid immediately with all non-JCK data, then fetch
+            // JCK console logs asynchronously and patch the result into state.
+            // This ensures a slow or failing remote Jenkins never blocks rendering.
             setState((prevState) => ({
                 ...prevState,
                 buildMap,
@@ -336,6 +414,9 @@ export default function ResultSummary() {
                 sdkBuilds,
                 javaVersion,
             }));
+
+            // Fetch JCK console results after the grid is already rendered
+            loadJckResults(jckBuilds || []);
         };
 
         updateData();


### PR DESCRIPTION
Fixes #1130 

When remotely triggering JCK tests on a private server, pull the remote job status and display it in the Grid view.  This functionality only happens if AQA_Test_Pipeline_JCK jobs are being queried on the main Jenkins server that launched the release pipeline.  This approach shares no details on specific test failures, only Jenkins job status.

In the case where the JCK test jobs are launched directly from the main Jenkins server (on internally running private Jenkins servers for example), the behaviour to populate the Grid view from those direct results remains unchanged, and will behave like the other test groups (functional, openjdk, perf, system, etc).

Assisted by IBM Bob 