### PR TITLE
Revert "Bump react-router from 7.16.0 to 8.3.0 in /test-result-summary-client"

### DIFF
--- a/test-result-summary-client/package-lock.json
+++ b/test-result-summary-client/package-lock.json
@@ -33,7 +33,7 @@
                 "react-jsx-highcharts": "^3.6.1",
                 "react-jsx-highstock": "^3.6.1",
                 "react-nl2br": "^1.0.4",
-                "react-router": "^8.3.0",
+                "react-router": "^7.16.0",
                 "react-router-dom": "^7.16.0",
                 "react-scripts": "^5.0.1",
                 "react-table": "^6.11.5",
@@ -6289,11 +6289,6 @@
             "engines": {
                 "node": ">= 0.6"
             }
-        },
-        "node_modules/cookie-es": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
-            "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg=="
         },
         "node_modules/cookie-signature": {
             "version": "1.0.6",
@@ -16483,18 +16478,19 @@
             }
         },
         "node_modules/react-router": {
-            "version": "8.3.0",
-            "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.3.0.tgz",
-            "integrity": "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==",
+            "version": "7.16.0",
+            "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.16.0.tgz",
+            "integrity": "sha512-wArC8lVyJb3+jM9OpDyW6hLCizACWkvQR/sSGqSs+o5uEXEtGlqdZ4v8hENR3Jad6i+LRkK93q/+bQAcvl6V1A==",
             "dependencies": {
-                "cookie-es": "^3.1.1"
+                "cookie": "^1.0.1",
+                "set-cookie-parser": "^2.6.0"
             },
             "engines": {
-                "node": ">=22.22.0"
+                "node": ">=20.0.0"
             },
             "peerDependencies": {
-                "react": ">=19.2.7",
-                "react-dom": ">=19.2.7"
+                "react": ">=18",
+                "react-dom": ">=18"
             },
             "peerDependenciesMeta": {
                 "react-dom": {
@@ -16517,37 +16513,13 @@
                 "react-dom": ">=18"
             }
         },
-        "node_modules/react-router-dom/node_modules/cookie": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-            "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+        "node_modules/react-router/node_modules/cookie": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+            "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+            "license": "MIT",
             "engines": {
                 "node": ">=18"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/express"
-            }
-        },
-        "node_modules/react-router-dom/node_modules/react-router": {
-            "version": "7.16.0",
-            "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.16.0.tgz",
-            "integrity": "sha512-wArC8lVyJb3+jM9OpDyW6hLCizACWkvQR/sSGqSs+o5uEXEtGlqdZ4v8hENR3Jad6i+LRkK93q/+bQAcvl6V1A==",
-            "dependencies": {
-                "cookie": "^1.0.1",
-                "set-cookie-parser": "^2.6.0"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            },
-            "peerDependencies": {
-                "react": ">=18",
-                "react-dom": ">=18"
-            },
-            "peerDependenciesMeta": {
-                "react-dom": {
-                    "optional": true
-                }
             }
         },
         "node_modules/react-scripts": {
@@ -17679,9 +17651,10 @@
             }
         },
         "node_modules/set-cookie-parser": {
-            "version": "2.7.2",
-            "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-            "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+            "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+            "license": "MIT"
         },
         "node_modules/set-function-length": {
             "version": "1.2.2",
@@ -24782,11 +24755,6 @@
             "version": "0.7.1",
             "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
             "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w=="
-        },
-        "cookie-es": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
-            "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg=="
         },
         "cookie-signature": {
             "version": "1.0.6",
@@ -32025,11 +31993,19 @@
             }
         },
         "react-router": {
-            "version": "8.3.0",
-            "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.3.0.tgz",
-            "integrity": "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==",
+            "version": "7.16.0",
+            "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.16.0.tgz",
+            "integrity": "sha512-wArC8lVyJb3+jM9OpDyW6hLCizACWkvQR/sSGqSs+o5uEXEtGlqdZ4v8hENR3Jad6i+LRkK93q/+bQAcvl6V1A==",
             "requires": {
-                "cookie-es": "^3.1.1"
+                "cookie": "^1.0.1",
+                "set-cookie-parser": "^2.6.0"
+            },
+            "dependencies": {
+                "cookie": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+                    "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA=="
+                }
             }
         },
         "react-router-dom": {
@@ -32038,22 +32014,6 @@
             "integrity": "sha512-kMUAbimWB5FVbF4Bce4bJsiKJWLIUHq/mEG8+CFDnCSgltptBiG5nguducmsJeGKytlCvQud9Qhzpn49iduTlA==",
             "requires": {
                 "react-router": "7.16.0"
-            },
-            "dependencies": {
-                "cookie": {
-                    "version": "1.1.1",
-                    "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-                    "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="
-                },
-                "react-router": {
-                    "version": "7.16.0",
-                    "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.16.0.tgz",
-                    "integrity": "sha512-wArC8lVyJb3+jM9OpDyW6hLCizACWkvQR/sSGqSs+o5uEXEtGlqdZ4v8hENR3Jad6i+LRkK93q/+bQAcvl6V1A==",
-                    "requires": {
-                        "cookie": "^1.0.1",
-                        "set-cookie-parser": "^2.6.0"
-                    }
-                }
             }
         },
         "react-scripts": {
@@ -32901,9 +32861,9 @@
             }
         },
         "set-cookie-parser": {
-            "version": "2.7.2",
-            "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-            "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+            "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ=="
         },
         "set-function-length": {
             "version": "1.2.2",

--- a/test-result-summary-client/package.json
+++ b/test-result-summary-client/package.json
@@ -28,7 +28,7 @@
         "react-jsx-highcharts": "^3.6.1",
         "react-jsx-highstock": "^3.6.1",
         "react-nl2br": "^1.0.4",
-        "react-router": "^8.3.0",
+        "react-router": "^7.16.0",
         "react-router-dom": "^7.16.0",
         "react-scripts": "^5.0.1",
         "react-table": "^6.11.5",


### PR DESCRIPTION
Reverts adoptium/aqa-test-tools#1273

related: https://github.com/adoptium/aqa-test-tools/issues/1285 